### PR TITLE
test: add video tutorials test coverage (#15)

### DIFF
--- a/tests/unit/components/VideoCard.test.ts
+++ b/tests/unit/components/VideoCard.test.ts
@@ -315,6 +315,68 @@ describe('VideoCard', () => {
     })
   })
 
+  describe('Level Color Mapping', () => {
+    it('should map basic level to success color', () => {
+      const video: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        level: 'basic'
+      }
+      const wrapper = mount(VideoCard, {
+        props: { video }
+      })
+      const chip = wrapper.find('ion-chip')
+      expect(chip.attributes('color')).toBe('success')
+    })
+
+    it(
+      'should map intermediate level to warning color',
+      () => {
+        const video: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          level: 'intermediate'
+        }
+        const wrapper = mount(VideoCard, {
+          props: { video }
+        })
+        const chip = wrapper.find('ion-chip')
+        expect(chip.attributes('color'))
+          .toBe('warning')
+      }
+    )
+
+    it(
+      'should map advanced level to danger color',
+      () => {
+        const video: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          level: 'advanced'
+        }
+        const wrapper = mount(VideoCard, {
+          props: { video }
+        })
+        const chip = wrapper.find('ion-chip')
+        expect(chip.attributes('color'))
+          .toBe('danger')
+      }
+    )
+
+    it(
+      'should default to success color for unknown level',
+      () => {
+        const video: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          level: 'expert'
+        }
+        const wrapper = mount(VideoCard, {
+          props: { video }
+        })
+        const chip = wrapper.find('ion-chip')
+        expect(chip.attributes('color'))
+          .toBe('success')
+      }
+    )
+  })
+
   describe('Edge Cases', () => {
     it('should handle very long query strings', () => {
       const longQueryVideo: ContentPublic = {

--- a/tests/unit/pages/index.test.ts
+++ b/tests/unit/pages/index.test.ts
@@ -1,0 +1,393 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach
+} from 'vitest'
+import { mount } from '@vue/test-utils'
+import { onMounted, reactive } from 'vue'
+import { flushPromises } from '../../setup/test-setup'
+
+// Make Vue lifecycle hooks globally available
+// (Nuxt auto-imports these but test-setup omits
+// lifecycle hooks)
+vi.stubGlobal('onMounted', onMounted)
+import {
+  freeVideoWithQueryParams,
+  premiumVideo
+} from '../../fixtures/videos'
+import type {
+  ContentPublic
+} from '../../../shared/types/api/content.types'
+
+// Mock swiper CSS imports
+vi.mock('swiper/css', () => ({}))
+vi.mock('swiper/css/navigation', () => ({}))
+vi.mock('swiper/css/pagination', () => ({}))
+vi.mock('swiper/css/autoplay', () => ({}))
+
+// Stub definePageMeta globally
+vi.stubGlobal('definePageMeta', vi.fn())
+
+// Import component under test after mocks
+import IndexPage from '~/pages/index.vue'
+
+const apiMock = vi.fn()
+
+const stubs = {
+  VideoCard: {
+    template: '<div class="video-card-stub" />',
+    props: ['video', 'featured']
+  },
+  'swiper-container': {
+    template: '<div><slot /></div>'
+  },
+  'swiper-slide': {
+    template: '<div><slot /></div>'
+  }
+}
+
+function mountPage(
+  overrides: {
+    authenticated?: boolean
+    apiResult?: unknown
+  } = {}
+) {
+  const {
+    authenticated = false,
+    apiResult = []
+  } = overrides
+
+  apiMock.mockResolvedValue(apiResult)
+
+  global.useApi = () => ({ api: apiMock })
+  global.useAuthStore = () => reactive({
+    user: null,
+    token: null,
+    isAuthenticated: authenticated,
+    setUser: vi.fn(),
+    setToken: vi.fn(),
+    logout: vi.fn(),
+    $patch: vi.fn(),
+    $reset: vi.fn(),
+    $subscribe: vi.fn()
+  })
+
+  return mount(IndexPage, {
+    global: { stubs }
+  })
+}
+
+describe('IndexPage', () => {
+  let randomSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    randomSpy = vi.spyOn(Math, 'random')
+      .mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    randomSpy.mockRestore()
+  })
+
+  describe('Featured Video Selection', () => {
+    it('calls API on mount', async () => {
+      mountPage({ apiResult: [] })
+      await flushPromises()
+
+      expect(apiMock).toHaveBeenCalledWith(
+        '/products/content/public'
+      )
+    })
+
+    it(
+      'filters out videos with null url',
+      async () => {
+        // premiumVideo has url=null, should not
+        // be selected even with Math.random=0
+        // Only freeVideoWithQueryParams qualifies
+        const wrapper = mountPage({
+          apiResult: [
+            premiumVideo,
+            freeVideoWithQueryParams
+          ]
+        })
+        await flushPromises()
+
+        const card = wrapper.findComponent(
+          stubs.VideoCard
+        )
+        expect(card.exists()).toBe(true)
+        expect(card.props('video')._id).toBe(
+          freeVideoWithQueryParams._id
+        )
+      }
+    )
+
+    it(
+      'filters out non-basic level videos',
+      async () => {
+        const intermediateVideo: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          _id: 'intermediate-1',
+          level: 'intermediate'
+        }
+        const wrapper = mountPage({
+          apiResult: [
+            intermediateVideo,
+            freeVideoWithQueryParams
+          ]
+        })
+        await flushPromises()
+
+        const card = wrapper.findComponent(
+          stubs.VideoCard
+        )
+        expect(card.exists()).toBe(true)
+        expect(card.props('video')._id).toBe(
+          freeVideoWithQueryParams._id
+        )
+      }
+    )
+
+    it(
+      'filters out videos with credits > 0',
+      async () => {
+        const paidBasic: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          _id: 'paid-basic-1',
+          credits: 5
+        }
+        const wrapper = mountPage({
+          apiResult: [
+            paidBasic,
+            freeVideoWithQueryParams
+          ]
+        })
+        await flushPromises()
+
+        const card = wrapper.findComponent(
+          stubs.VideoCard
+        )
+        expect(card.exists()).toBe(true)
+        expect(card.props('video')._id).toBe(
+          freeVideoWithQueryParams._id
+        )
+      }
+    )
+
+    it(
+      'uses Math.random to select from pool',
+      async () => {
+        const second: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          _id: 'second-free'
+        }
+        randomSpy.mockReturnValue(0.99)
+
+        const wrapper = mountPage({
+          apiResult: [
+            freeVideoWithQueryParams,
+            second
+          ]
+        })
+        await flushPromises()
+
+        const card = wrapper.findComponent(
+          stubs.VideoCard
+        )
+        expect(card.exists()).toBe(true)
+        // floor(0.99 * 2) = 1 => second video
+        expect(card.props('video')._id).toBe(
+          'second-free'
+        )
+      }
+    )
+  })
+
+  describe('Display Logic', () => {
+    it(
+      'renders VideoCard with featured=true',
+      async () => {
+        const wrapper = mountPage({
+          apiResult: [freeVideoWithQueryParams]
+        })
+        await flushPromises()
+
+        const card = wrapper.findComponent(
+          stubs.VideoCard
+        )
+        expect(card.exists()).toBe(true)
+        expect(card.props('featured')).toBe(true)
+      }
+    )
+
+    it(
+      'View All button links to /tutorials',
+      async () => {
+        const wrapper = mountPage({
+          apiResult: [freeVideoWithQueryParams]
+        })
+        await flushPromises()
+
+        const buttons = wrapper.findAll(
+          'ion-button'
+        )
+        const viewAll = buttons.find(
+          b => b.text().includes(
+            'home.featuredVideo.viewAll'
+          )
+        )
+        expect(viewAll).toBeDefined()
+        expect(
+          viewAll!.attributes('router-link')
+        ).toBe('/tutorials')
+      }
+    )
+
+    it(
+      'hides featured section while loading',
+      () => {
+        // Do not await flushPromises so
+        // loadingVideo stays true
+        apiMock.mockReturnValue(
+          new Promise(() => {})
+        )
+        global.useApi = () => ({ api: apiMock })
+
+        const wrapper = mount(IndexPage, {
+          global: { stubs }
+        })
+
+        const grid = wrapper.find('.featured-grid')
+        expect(grid.exists()).toBe(false)
+      }
+    )
+  })
+
+  describe('Error Handling', () => {
+    it(
+      'does not show error UI on API failure',
+      async () => {
+        apiMock.mockRejectedValue(
+          new Error('Network error')
+        )
+        global.useApi = () => ({ api: apiMock })
+
+        const wrapper = mount(IndexPage, {
+          global: { stubs }
+        })
+        await flushPromises()
+
+        expect(
+          wrapper.find('.error').exists()
+        ).toBe(false)
+        expect(
+          wrapper.find('[role="alert"]').exists()
+        ).toBe(false)
+      }
+    )
+
+    it(
+      'hides featured section on API error',
+      async () => {
+        apiMock.mockRejectedValue(
+          new Error('Server error')
+        )
+        global.useApi = () => ({ api: apiMock })
+
+        const wrapper = mount(IndexPage, {
+          global: { stubs }
+        })
+        await flushPromises()
+
+        expect(
+          wrapper.find('.featured-grid').exists()
+        ).toBe(false)
+      }
+    )
+  })
+
+  describe('Authentication States', () => {
+    it(
+      'shows register and login when not auth',
+      async () => {
+        const wrapper = mountPage({
+          authenticated: false,
+          apiResult: []
+        })
+        await flushPromises()
+
+        const text = wrapper.text()
+        expect(text).toContain('home.getStarted')
+        expect(text).toContain('home.signIn')
+        expect(text).not.toContain(
+          'home.manageAccount'
+        )
+      }
+    )
+
+    it(
+      'shows account button when authenticated',
+      async () => {
+        const wrapper = mountPage({
+          authenticated: true,
+          apiResult: []
+        })
+        await flushPromises()
+
+        const text = wrapper.text()
+        expect(text).toContain(
+          'home.manageAccount'
+        )
+        expect(text).not.toContain(
+          'home.getStarted'
+        )
+        expect(text).not.toContain(
+          'home.signIn'
+        )
+      }
+    )
+  })
+
+  describe('Edge Cases', () => {
+    it(
+      'no featured video when all premium',
+      async () => {
+        const wrapper = mountPage({
+          apiResult: [premiumVideo]
+        })
+        await flushPromises()
+
+        expect(
+          wrapper.find('.featured-grid').exists()
+        ).toBe(false)
+      }
+    )
+
+    it(
+      'selects the only matching video',
+      async () => {
+        randomSpy.mockReturnValue(0)
+
+        const wrapper = mountPage({
+          apiResult: [
+            premiumVideo,
+            freeVideoWithQueryParams
+          ]
+        })
+        await flushPromises()
+
+        const card = wrapper.findComponent(
+          stubs.VideoCard
+        )
+        expect(card.exists()).toBe(true)
+        expect(card.props('video')._id).toBe(
+          freeVideoWithQueryParams._id
+        )
+      }
+    )
+  })
+})

--- a/tests/unit/pages/index.test.ts
+++ b/tests/unit/pages/index.test.ts
@@ -9,11 +9,6 @@ import {
 import { mount } from '@vue/test-utils'
 import { onMounted, reactive } from 'vue'
 import { flushPromises } from '../../setup/test-setup'
-
-// Make Vue lifecycle hooks globally available
-// (Nuxt auto-imports these but test-setup omits
-// lifecycle hooks)
-vi.stubGlobal('onMounted', onMounted)
 import {
   freeVideoWithQueryParams,
   premiumVideo
@@ -21,6 +16,11 @@ import {
 import type {
   ContentPublic
 } from '../../../shared/types/api/content.types'
+
+// Make Vue lifecycle hooks globally available
+// (Nuxt auto-imports these but test-setup omits
+// lifecycle hooks)
+vi.stubGlobal('onMounted', onMounted)
 
 // Mock swiper CSS imports
 vi.mock('swiper/css', () => ({}))
@@ -32,6 +32,7 @@ vi.mock('swiper/css/autoplay', () => ({}))
 vi.stubGlobal('definePageMeta', vi.fn())
 
 // Import component under test after mocks
+// eslint-disable-next-line import/first
 import IndexPage from '~/pages/index.vue'
 
 const apiMock = vi.fn()
@@ -62,18 +63,22 @@ function mountPage(
 
   apiMock.mockResolvedValue(apiResult)
 
-  global.useApi = () => ({ api: apiMock })
-  global.useAuthStore = () => reactive({
-    user: null,
-    token: null,
-    isAuthenticated: authenticated,
-    setUser: vi.fn(),
-    setToken: vi.fn(),
-    logout: vi.fn(),
-    $patch: vi.fn(),
-    $reset: vi.fn(),
-    $subscribe: vi.fn()
-  })
+  vi.stubGlobal(
+    'useApi', () => ({ api: apiMock })
+  )
+  vi.stubGlobal(
+    'useAuthStore', () => reactive({
+      user: null,
+      token: null,
+      isAuthenticated: authenticated,
+      setUser: vi.fn(),
+      setToken: vi.fn(),
+      logout: vi.fn(),
+      $patch: vi.fn(),
+      $reset: vi.fn(),
+      $subscribe: vi.fn()
+    })
+  )
 
   return mount(IndexPage, {
     global: { stubs }
@@ -84,6 +89,7 @@ describe('IndexPage', () => {
   let randomSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    apiMock.mockReset()
     randomSpy = vi.spyOn(Math, 'random')
       .mockReturnValue(0)
   })
@@ -255,7 +261,22 @@ describe('IndexPage', () => {
         apiMock.mockReturnValue(
           new Promise(() => {})
         )
-        global.useApi = () => ({ api: apiMock })
+        vi.stubGlobal(
+          'useApi', () => ({ api: apiMock })
+        )
+        vi.stubGlobal(
+          'useAuthStore', () => reactive({
+            user: null,
+            token: null,
+            isAuthenticated: false,
+            setUser: vi.fn(),
+            setToken: vi.fn(),
+            logout: vi.fn(),
+            $patch: vi.fn(),
+            $reset: vi.fn(),
+            $subscribe: vi.fn()
+          })
+        )
 
         const wrapper = mount(IndexPage, {
           global: { stubs }
@@ -274,7 +295,22 @@ describe('IndexPage', () => {
         apiMock.mockRejectedValue(
           new Error('Network error')
         )
-        global.useApi = () => ({ api: apiMock })
+        vi.stubGlobal(
+          'useApi', () => ({ api: apiMock })
+        )
+        vi.stubGlobal(
+          'useAuthStore', () => reactive({
+            user: null,
+            token: null,
+            isAuthenticated: false,
+            setUser: vi.fn(),
+            setToken: vi.fn(),
+            logout: vi.fn(),
+            $patch: vi.fn(),
+            $reset: vi.fn(),
+            $subscribe: vi.fn()
+          })
+        )
 
         const wrapper = mount(IndexPage, {
           global: { stubs }
@@ -296,7 +332,22 @@ describe('IndexPage', () => {
         apiMock.mockRejectedValue(
           new Error('Server error')
         )
-        global.useApi = () => ({ api: apiMock })
+        vi.stubGlobal(
+          'useApi', () => ({ api: apiMock })
+        )
+        vi.stubGlobal(
+          'useAuthStore', () => reactive({
+            user: null,
+            token: null,
+            isAuthenticated: false,
+            setUser: vi.fn(),
+            setToken: vi.fn(),
+            logout: vi.fn(),
+            $patch: vi.fn(),
+            $reset: vi.fn(),
+            $subscribe: vi.fn()
+          })
+        )
 
         const wrapper = mount(IndexPage, {
           global: { stubs }

--- a/tests/unit/pages/tutorials.test.ts
+++ b/tests/unit/pages/tutorials.test.ts
@@ -1,0 +1,607 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, VueWrapper } from '@vue/test-utils'
+import {
+  onMounted,
+  onUnmounted,
+  onBeforeMount,
+  onBeforeUnmount
+} from 'vue'
+import { flushPromises } from '../../setup/test-setup'
+import type { ContentPublic } from
+  '../../../shared/types/api/content.types'
+import {
+  freeVideoWithQueryParams,
+  freeVideoNoQueryParams,
+  premiumVideo,
+  directVimeoUrlWithWww,
+  directVimeoUrlNoWww,
+  videoWithManyQueryParams,
+  validVideos,
+  allVideos
+} from '../../fixtures/videos'
+
+// Make Vue lifecycle hooks available as globals
+// so compiled SFC code can reference them
+vi.stubGlobal('onMounted', onMounted)
+vi.stubGlobal('onUnmounted', onUnmounted)
+vi.stubGlobal('onBeforeMount', onBeforeMount)
+vi.stubGlobal('onBeforeUnmount', onBeforeUnmount)
+
+// Stub Nuxt macros
+vi.stubGlobal('definePageMeta', vi.fn())
+
+// Import page after globals are set (top-level await)
+const { default: TutorialsPage } =
+  await import('~/pages/tutorials.vue')
+
+// Helper: videos with non-null URLs from allVideos
+const videosWithUrls = allVideos.filter(
+  v => v.url !== null
+)
+
+/**
+ * Mount tutorials page with a mocked API response.
+ * By default returns videosWithUrls.
+ * Pass `apiResponse` to override, or `apiError` to
+ * simulate a failure.
+ */
+async function mountPage(opts: {
+  apiResponse?: ContentPublic[]
+  apiError?: boolean
+  skipFlush?: boolean
+} = {}): Promise<{
+  wrapper: VueWrapper
+  mockApi: ReturnType<typeof vi.fn>
+}> {
+  const mockApi = vi.fn()
+
+  if (opts.apiError) {
+    mockApi.mockRejectedValueOnce(
+      new Error('Network error')
+    )
+  } else {
+    mockApi.mockResolvedValueOnce(
+      opts.apiResponse ?? allVideos
+    )
+  }
+
+  vi.stubGlobal(
+    'useApi',
+    () => ({ api: mockApi })
+  )
+
+  const wrapper = mount(TutorialsPage, {
+    global: {
+      stubs: {
+        LoadingSpinner: {
+          template:
+            '<div class="loading-stub">loading</div>'
+        },
+        ErrorCard: {
+          template:
+            '<div class="error-stub">' +
+            '<button class="retry" ' +
+            '@click="$attrs[\'retry-action\']()">' +
+            'retry</button></div>',
+          inheritAttrs: false
+        },
+        VideoCard: {
+          template:
+            '<div class="video-card-stub">' +
+            '{{ video.title }}</div>',
+          props: ['video']
+        }
+      }
+    }
+  })
+
+  if (!opts.skipFlush) {
+    await flushPromises()
+  }
+
+  return { wrapper, mockApi }
+}
+
+describe('TutorialsPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.stubGlobal('definePageMeta', vi.fn())
+  })
+
+  // -----------------------------------------------
+  // 1. API Integration
+  // -----------------------------------------------
+  describe('API Integration', () => {
+    it('calls API on mount with correct endpoint',
+      async () => {
+        const { mockApi } = await mountPage()
+        expect(mockApi).toHaveBeenCalledWith(
+          '/products/content/public'
+        )
+      }
+    )
+
+    it('shows loading state before API resolves',
+      async () => {
+        const { wrapper } = await mountPage({
+          skipFlush: true
+        })
+        expect(
+          wrapper.find('.loading-stub').exists()
+        ).toBe(true)
+      }
+    )
+
+    it('shows error state on API failure with retry',
+      async () => {
+        const { wrapper, mockApi } = await mountPage({
+          apiError: true
+        })
+
+        expect(
+          wrapper.find('.error-stub').exists()
+        ).toBe(true)
+
+        // Setup a successful retry
+        mockApi.mockResolvedValueOnce(allVideos)
+        await wrapper.find('.retry').trigger('click')
+        await flushPromises()
+
+        expect(
+          wrapper.find('.error-stub').exists()
+        ).toBe(false)
+        expect(mockApi).toHaveBeenCalledTimes(2)
+      }
+    )
+  })
+
+  // -----------------------------------------------
+  // 2. Search Filtering
+  // -----------------------------------------------
+  describe('Search Filtering', () => {
+    it('filters by title case-insensitively',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.searchQuery = 'breeding basics'
+        await wrapper.vm.$nextTick()
+
+        const filtered = vm.filteredVideos
+        expect(filtered.length).toBeGreaterThan(0)
+        expect(
+          filtered.every((v: ContentPublic) =>
+            v.title.toLowerCase()
+              .includes('breeding basics')
+          )
+        ).toBe(true)
+      }
+    )
+
+    it('filters by description case-insensitively',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.searchQuery = 'FUNDAMENTALS'
+        await wrapper.vm.$nextTick()
+
+        const filtered = vm.filteredVideos
+        expect(filtered.length).toBeGreaterThan(0)
+        expect(
+          filtered.some((v: ContentPublic) =>
+            v.description.toLowerCase()
+              .includes('fundamentals')
+          )
+        ).toBe(true)
+      }
+    )
+
+    it('shows all videos when search is empty',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.searchQuery = ''
+        await wrapper.vm.$nextTick()
+
+        expect(vm.filteredVideos.length).toBe(
+          videosWithUrls.length
+        )
+      }
+    )
+
+    it('handles special characters without crash',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.searchQuery = '.*+?^${}()|[]\\'
+        await wrapper.vm.$nextTick()
+
+        // Should not throw; may return 0 results
+        expect(vm.filteredVideos).toBeDefined()
+      }
+    )
+  })
+
+  // -----------------------------------------------
+  // 3. Level Filtering
+  // -----------------------------------------------
+  describe('Level Filtering', () => {
+    it('filters by a single level', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.selectedLevels = ['basic']
+      await wrapper.vm.$nextTick()
+
+      const filtered = vm.filteredVideos
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(
+        filtered.every(
+          (v: ContentPublic) => v.level === 'basic'
+        )
+      ).toBe(true)
+    })
+
+    it('filters by multiple levels (OR)',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.selectedLevels = ['basic', 'advanced']
+        await wrapper.vm.$nextTick()
+
+        const filtered = vm.filteredVideos
+        expect(filtered.length).toBeGreaterThan(0)
+        expect(
+          filtered.every((v: ContentPublic) =>
+            ['basic', 'advanced'].includes(v.level)
+          )
+        ).toBe(true)
+      }
+    )
+
+    it('restores all when filter is cleared',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.selectedLevels = ['basic']
+        await wrapper.vm.$nextTick()
+        const countWithFilter = vm.filteredVideos.length
+
+        vm.selectedLevels = []
+        await wrapper.vm.$nextTick()
+        expect(vm.filteredVideos.length)
+          .toBeGreaterThan(countWithFilter)
+      }
+    )
+  })
+
+  // -----------------------------------------------
+  // 4. Tag Filtering
+  // -----------------------------------------------
+  describe('Tag Filtering', () => {
+    it('category tags use OR logic', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.selectedCategoryTags = ['breeding', 'rearing']
+      await wrapper.vm.$nextTick()
+
+      const filtered = vm.filteredVideos
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(
+        filtered.every((v: ContentPublic) =>
+          v.category_tags.some(
+            t => ['breeding', 'rearing'].includes(t)
+          )
+        )
+      ).toBe(true)
+    })
+
+    it('profile tags use OR logic', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.selectedProfileTags = ['newbie', 'business']
+      await wrapper.vm.$nextTick()
+
+      const filtered = vm.filteredVideos
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(
+        filtered.every((v: ContentPublic) =>
+          v.profile_tags.some(
+            t => ['newbie', 'business'].includes(t)
+          )
+        )
+      ).toBe(true)
+    })
+
+    it('combines level + tags with AND logic',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.selectedLevels = ['basic']
+        vm.selectedCategoryTags = ['breeding']
+        await wrapper.vm.$nextTick()
+
+        const filtered = vm.filteredVideos
+        expect(
+          filtered.every((v: ContentPublic) =>
+            v.level === 'basic' &&
+            v.category_tags.includes('breeding')
+          )
+        ).toBe(true)
+      }
+    )
+  })
+
+  // -----------------------------------------------
+  // 5. Sorting
+  // -----------------------------------------------
+  describe('Sorting', () => {
+    it('sorts by credits ascending', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.sortBy = 'credits'
+      vm.sortDirection = 'asc'
+      await wrapper.vm.$nextTick()
+
+      const credits = vm.filteredVideos.map(
+        (v: ContentPublic) => v.credits
+      )
+      for (let i = 1; i < credits.length; i++) {
+        expect(credits[i]).toBeGreaterThanOrEqual(
+          credits[i - 1]
+        )
+      }
+    })
+
+    it('sorts by credits descending', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.sortBy = 'credits'
+      vm.sortDirection = 'desc'
+      await wrapper.vm.$nextTick()
+
+      const credits = vm.filteredVideos.map(
+        (v: ContentPublic) => v.credits
+      )
+      for (let i = 1; i < credits.length; i++) {
+        expect(credits[i]).toBeLessThanOrEqual(
+          credits[i - 1]
+        )
+      }
+    })
+
+    it('sorts by title ascending', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.sortBy = 'title'
+      vm.sortDirection = 'asc'
+      await wrapper.vm.$nextTick()
+
+      const titles = vm.filteredVideos.map(
+        (v: ContentPublic) => v.title
+      )
+      for (let i = 1; i < titles.length; i++) {
+        expect(
+          titles[i].localeCompare(titles[i - 1])
+        ).toBeGreaterThanOrEqual(0)
+      }
+    })
+
+    it('sorts by title descending', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.sortBy = 'title'
+      vm.sortDirection = 'desc'
+      await wrapper.vm.$nextTick()
+
+      const titles = vm.filteredVideos.map(
+        (v: ContentPublic) => v.title
+      )
+      for (let i = 1; i < titles.length; i++) {
+        expect(
+          titles[i].localeCompare(titles[i - 1])
+        ).toBeLessThanOrEqual(0)
+      }
+    })
+
+    it('sorts by date ascending', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.sortBy = 'date'
+      vm.sortDirection = 'asc'
+      await wrapper.vm.$nextTick()
+
+      const dates = vm.filteredVideos.map(
+        (v: ContentPublic) =>
+          new Date(v.created_at).getTime()
+      )
+      for (let i = 1; i < dates.length; i++) {
+        expect(dates[i]).toBeGreaterThanOrEqual(
+          dates[i - 1]
+        )
+      }
+    })
+
+    it('sorts by date descending', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as any
+      vm.sortBy = 'date'
+      vm.sortDirection = 'desc'
+      await wrapper.vm.$nextTick()
+
+      const dates = vm.filteredVideos.map(
+        (v: ContentPublic) =>
+          new Date(v.created_at).getTime()
+      )
+      for (let i = 1; i < dates.length; i++) {
+        expect(dates[i]).toBeLessThanOrEqual(
+          dates[i - 1]
+        )
+      }
+    })
+  })
+
+  // -----------------------------------------------
+  // 6. Tag Extraction
+  // -----------------------------------------------
+  describe('Tag Extraction', () => {
+    it('extracts unique sorted category tags',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        const tags = vm.availableCategoryTags
+
+        // Should be sorted
+        for (let i = 1; i < tags.length; i++) {
+          expect(
+            tags[i].localeCompare(tags[i - 1])
+          ).toBeGreaterThanOrEqual(0)
+        }
+        // Should be unique
+        expect(tags.length).toBe(
+          new Set(tags).size
+        )
+      }
+    )
+
+    it('extracts unique sorted profile tags',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        const tags = vm.availableProfileTags
+
+        // Should be sorted
+        for (let i = 1; i < tags.length; i++) {
+          expect(
+            tags[i].localeCompare(tags[i - 1])
+          ).toBeGreaterThanOrEqual(0)
+        }
+        // Should be unique
+        expect(tags.length).toBe(
+          new Set(tags).size
+        )
+      }
+    )
+  })
+
+  // -----------------------------------------------
+  // 7. States
+  // -----------------------------------------------
+  describe('States', () => {
+    it('shows empty state when no videos match',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        vm.searchQuery = 'zzz_no_match_ever_zzz'
+        await wrapper.vm.$nextTick()
+
+        expect(vm.filteredVideos.length).toBe(0)
+        expect(
+          wrapper.text()
+        ).toContain('tutorials.empty.title')
+      }
+    )
+
+    it('results count updates with filtering',
+      async () => {
+        const { wrapper } = await mountPage()
+        const vm = wrapper.vm as any
+        const allCount = vm.filteredVideos.length
+
+        vm.selectedLevels = ['advanced']
+        await wrapper.vm.$nextTick()
+        const filteredCount = vm.filteredVideos.length
+
+        expect(filteredCount).toBeLessThan(allCount)
+        expect(
+          wrapper.find('.results-count').exists()
+        ).toBe(true)
+      }
+    )
+
+    it('filters out videos with url=null',
+      async () => {
+        const { wrapper } = await mountPage({
+          apiResponse: [
+            freeVideoWithQueryParams,
+            premiumVideo
+          ]
+        })
+        const vm = wrapper.vm as any
+
+        // premiumVideo has url: null
+        expect(vm.filteredVideos.length).toBe(1)
+        expect(
+          vm.filteredVideos.every(
+            (v: ContentPublic) => v.url !== null
+          )
+        ).toBe(true)
+      }
+    )
+  })
+
+  // -----------------------------------------------
+  // 8. Edge Cases
+  // -----------------------------------------------
+  describe('Edge Cases', () => {
+    it('handles empty API response', async () => {
+      const { wrapper } = await mountPage({
+        apiResponse: []
+      })
+      const vm = wrapper.vm as any
+
+      expect(vm.filteredVideos.length).toBe(0)
+      expect(
+        wrapper.find('.error-stub').exists()
+      ).toBe(false)
+    })
+
+    it('searches safely with null title/description',
+      async () => {
+        const nullFieldVideo: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          _id: 'null-fields',
+          title: null as unknown as string,
+          description: null as unknown as string
+        }
+
+        const { wrapper } = await mountPage({
+          apiResponse: [
+            freeVideoWithQueryParams,
+            nullFieldVideo
+          ]
+        })
+        const vm = wrapper.vm as any
+        vm.searchQuery = 'breeding'
+        await wrapper.vm.$nextTick()
+
+        // Should not throw
+        expect(vm.filteredVideos).toBeDefined()
+      }
+    )
+
+    it('sorts by date with missing created_at',
+      async () => {
+        const noDateVideo: ContentPublic = {
+          ...freeVideoWithQueryParams,
+          _id: 'no-date',
+          created_at: '' as string
+        }
+
+        const { wrapper } = await mountPage({
+          apiResponse: [
+            freeVideoNoQueryParams,
+            noDateVideo
+          ]
+        })
+        const vm = wrapper.vm as any
+        vm.sortBy = 'date'
+        vm.sortDirection = 'asc'
+        await wrapper.vm.$nextTick()
+
+        // Should not throw
+        expect(
+          vm.filteredVideos.length
+        ).toBeGreaterThan(0)
+      }
+    )
+  })
+})

--- a/tests/unit/pages/tutorials.test.ts
+++ b/tests/unit/pages/tutorials.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mount, VueWrapper } from '@vue/test-utils'
+import { mount } from '@vue/test-utils'
+import type { VueWrapper } from '@vue/test-utils'
 import {
   onMounted,
   onUnmounted,
@@ -13,10 +14,6 @@ import {
   freeVideoWithQueryParams,
   freeVideoNoQueryParams,
   premiumVideo,
-  directVimeoUrlWithWww,
-  directVimeoUrlNoWww,
-  videoWithManyQueryParams,
-  validVideos,
   allVideos
 } from '../../fixtures/videos'
 
@@ -41,7 +38,7 @@ const videosWithUrls = allVideos.filter(
 
 /**
  * Mount tutorials page with a mocked API response.
- * By default returns videosWithUrls.
+ * By default returns allVideos.
  * Pass `apiResponse` to override, or `apiError` to
  * simulate a failure.
  */
@@ -187,7 +184,9 @@ describe('TutorialsPage', () => {
         const filtered = vm.filteredVideos
         expect(filtered.length).toBeGreaterThan(0)
         expect(
-          filtered.some((v: ContentPublic) =>
+          filtered.every((v: ContentPublic) =>
+            v.title.toLowerCase()
+              .includes('fundamentals') ||
             v.description.toLowerCase()
               .includes('fundamentals')
           )


### PR DESCRIPTION
## Summary

- Add **27 unit tests** for tutorials page: API integration, search/level/tag filtering, sorting (credits/title/date asc/desc), tag extraction, empty/error states, edge cases
- Add **14 unit tests** for index page: featured video selection logic, display/auth states, error handling, edge cases
- Add **4 unit tests** for VideoCard level color mapping (basic→success, intermediate→warning, advanced→danger, default→success)
- **Zero production code changes** — tests only
- All **500 tests pass** (up from 455), execution time under 9 seconds

## Test plan

- [x] `npm run test -- --run` passes (500/500 green)
- [x] No production files modified
- [x] Deterministic tests (Math.random mocked, API fully mocked)
- [x] 79-char line limit enforced

Closes #15

Generated by flow_ai workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added three new comprehensive unit test suites (VideoCard, Index page, Tutorials page) covering level color mapping, featured selection and API behavior, search, filtering, sorting, retry/error flows, UI states, and multiple edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->