### PR TITLE
fix: add explicit vue-i18n imports and unblock CI lint/format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,6 @@ dist
 ios
 android
 coverage
+.claude
 *.min.js
 *.min.css

--- a/FLOW_TEMPLATE.md
+++ b/FLOW_TEMPLATE.md
@@ -697,7 +697,12 @@ When creating or updating GitHub issues, use this structure:
     - Who to ask + preferred channel
     - Clarification etiquette and response SLA
 
-**Optional Section (if backend involved):** 18. **🔌 Backend Integration**: API endpoints, data models, auth
+**Optional Section (if backend involved):**
+
+18. **🔌 Backend Integration**
+    - API endpoints
+    - data models
+    - auth
 
 **Quality Requirements:**
 

--- a/FLOW_TEMPLATE.md
+++ b/FLOW_TEMPLATE.md
@@ -14,6 +14,7 @@
 
 This file contains **10 numbered sections** that define project
 configuration. Each section has:
+
 - **Required fields**: Must be filled (marked with `[...]`)
 - **Optional fields**: Can be removed if not applicable (in `<!--`)
 - **Examples**: Show format (marked with `e.g.,`)
@@ -85,12 +86,13 @@ A properly initialized FLOW.md has:
   If unclear, ask the user explicitly.
 - Line Length: 79 for Python, 80 for others
 - Indentation: 4 spaces for Python, 2 for JS/TS, language default
-- Branch Naming: feature/*, fix/*, chore/*
+- Branch Naming: feature/_, fix/_, chore/\*
 - Commit Messages: Conventional Commits
 - Default Branch: main
 - Test Framework: pytest (Python), Jest (JS/TS), None
 
 **Directory Defaults**:
+
 - Documentation: `docs/`
 - Tests: `tests/` (Python), `test/` or `__tests__/` (JS/TS)
 - Source Code: `src/` (most projects), `lib/` (libraries), root (simple
@@ -114,6 +116,7 @@ A properly initialized FLOW.md has:
 **Purpose**: [Brief description of what this project does]
 
 **Tech Stack**:
+
 - Stack Type: [backend, frontend, or fullstack]
 - Primary Language: [e.g., Python, TypeScript, Rust]
 - Framework: [e.g., FastAPI, React, None]
@@ -121,6 +124,7 @@ A properly initialized FLOW.md has:
 - Key Dependencies: [List major dependencies]
 
 **Repository Structure**:
+
 ```
 project/
 ├── .claude/           # Commands and agents
@@ -141,6 +145,7 @@ project/
 ```
 
 **Metadata Requirements Overview**:
+
 - All reference, analysis, and report markdown files must include YAML
   frontmatter that satisfies `docs/metadata-taxonomy.yaml`.
 - Required fields: `title`, `date`, `topics`, `tags`, `source` with
@@ -149,6 +154,7 @@ project/
   edits using `./flow.py index-build`.
 
 **Quick Start Commands**:
+
 - `./flow.py import-document <path>` – ingest files from `imports/new/`
   and generate compliant references with metadata.
 - `./flow.py validate-metadata [folder]` – verify metadata against the
@@ -161,6 +167,7 @@ project/
 <!-- Define all standard directories used by slash commands -->
 
 **Project Documentation**:
+
 - **Location**: `docs/` (default)
 - **Purpose**: Project-related documents, PRDs, architecture docs,
   templates
@@ -170,18 +177,21 @@ project/
   files)
 
 **Test Directory**:
+
 - **Location**: [e.g., `tests/`, `test/`, `__tests__/`, `src/test/`]
 - **Purpose**: Test files and test fixtures
 - **Used by**: All implementation and review commands
 - **Structure**: [e.g., mirrors src/ structure, organized by test type]
 
 **Application/Code Directory**:
+
 - **Location**: [e.g., `src/`, `app/`, `lib/`, project root]
 - **Purpose**: Main application source code
 - **Used by**: All coding commands
 - **Structure**: [Describe module organization]
 
 **Research Tasks**:
+
 - **Location**: `[tasks_dir]` (default `tasks/`)
 - **Purpose**: Research task definitions and lifecycle tracking
 - **Used by**:
@@ -192,6 +202,7 @@ project/
 - **Subdirectories**: `[tasks_dir]/completed/` - Archived tasks
 
 **Internal Knowledge Base**:
+
 - **Location**: `[references_dir]` (default `references/`)
 - **Purpose**: Metadata-compliant research corpus
 - **Used by**:
@@ -203,12 +214,14 @@ project/
 - **Metadata**: Must satisfy `docs/metadata-taxonomy.yaml`
 
 **Analysis Workspace**:
+
 - **Location**: `[analysis_dir]` (default `analysis/`)
 - **Purpose**: AI-generated analyses with YAML metadata
 - **Used by**: `/analysis:create`, `/research:maintain-report`
 - **File naming**: `analysis-[topic]-[YYYY-MM-DD].md`
 
 **Import Pipeline Root**:
+
 - **Location**: `[imports_root]` (default `imports/`)
 - **Purpose**: Stage raw files, convert, and archive originals
 - **Used by**: `/utils:convert-pdf`, `/research:import-document`
@@ -225,6 +238,7 @@ project/
   `.gitignore` (directory placeholder files for git tracking)
 
 **Report Synthesis**:
+
 - **Location**: `[report_dir]` (default `reports/`)
 - **Topic Index**: `[report_index]` (default `000-topic-reference.md`)
 - **Purpose**: Client-facing deliverables with YAML metadata
@@ -240,18 +254,21 @@ project/
 - **File naming**: `NN-chapter-title.md`
 
 **Search Index Artefacts**:
+
 - **Location**: `[index_dir]` (default `index/`)
 - **Purpose**: Structured search outputs built from metadata
 - **Used by**: `/research:index-build`, `/research:index-query`
 - **Maintenance**: Rebuild after imports or taxonomy changes
 
 **Temporary Files**:
+
 - **Location**: `/tmp/` (system temp, default)
 - **Purpose**: Temporary downloads, attachments, intermediate processing
 - **Used by**: `/sw:analyse-issue` (for attachments), various commands
 - **Cleanup**: Automatically cleared by system, not committed to git
 
 **Build/Generated Files**:
+
 - **Location**: [e.g., `dist/`, `build/`, `.next/`, `target/`]
 - **Purpose**: Compiled artifacts, build output (gitignored)
 - **Used by**: Build and deployment workflows
@@ -280,6 +297,7 @@ project/
 ### Sub-Agent Delegation
 
 When delegating to sub-agents:
+
 - **Filter Information**: Share only relevant sections from this file
 - **Specify Scope**: Clearly define the sub-task boundaries
 - **Provide Context**: Include necessary tech stack details
@@ -349,11 +367,13 @@ Agents do NOT duplicate this locally.
 
 **Test file discovery pattern**:
 How to find the test file for a given source file:
+
 - [e.g., `src/foo.py` → `tests/test_foo.py`]
 - [e.g., `src/components/Foo.tsx` → `src/components/Foo.test.tsx`]
 - [e.g., `pkg/foo/bar.go` → `pkg/foo/bar_test.go`]
 
 **What agents should NOT run**:
+
 - Full test suite (CI/CD handles this)
 - E2E tests (manual or CI/CD only)
 - Performance/load tests
@@ -445,6 +465,7 @@ How to find the test file for a given source file:
 
 ```markdown
 When sub-agents need guidance:
+
 1. Read FLOW.md sections relevant to the task
 2. Extract applicable rules and tech stack info
 3. Include in sub-agent prompt with clear scope
@@ -454,6 +475,7 @@ When sub-agents need guidance:
 ### Command Reading Requirements
 
 **Software Development Commands** (need Section 3 + 5 + 6):
+
 - `/sw:analyse-issue`: Read Sections 3, 6 (Issue Template)
 - `/sw:implement-issue`: Read Sections 1, 3, 5, 6 (Implementation)
 - `/sw:continue-implementation`: Read Sections 1, 3, 5, 6
@@ -463,6 +485,7 @@ When sub-agents need guidance:
 - `/sw:create-issue`: Read Sections 1, 3, 6 (Issue Template)
 
 **Research Commands**:
+
 - `/research:import-document`: Sections 1 (Import Pipeline,
   Knowledge Base), 3, 6, 10
 - `/research:validate-metadata`: Sections 1 (Import Pipeline,
@@ -482,11 +505,13 @@ When sub-agents need guidance:
 - `/research:archive-task`: Sections 1 (Research Tasks), 3, 6, 10
 
 **Utility Commands**:
+
 - `/utils:init-flow`: Reads FLOW.md template itself
 - `/utils:convert-pdf`: Sections 1 (Import Pipeline), 3
 - `/utils:update-flow`: No FLOW.md reading needed
 
 **Status Commands** (no FLOW.md needed):
+
 - `/sw:pull-request-check`: Uses GitHub API only
 - `/sw:pull-request-merge`: Uses git/gh CLI only
 
@@ -495,6 +520,7 @@ When sub-agents need guidance:
 ### Version Control
 
 **Git** (Required)
+
 - Purpose: Source control operations
 - Common commands:
   ```bash
@@ -505,6 +531,7 @@ When sub-agents need guidance:
   ```
 
 **GitHub CLI** (gh)
+
 - Purpose: GitHub API interactions
 - Authentication: Assumes `gh auth login` completed
 - Common commands:
@@ -572,6 +599,7 @@ and workflow patterns.
 When creating or updating GitHub issues, use this structure:
 
 **Issue Title Format:**
+
 ```
 [TYPE]: Concise summary (READY)
 ```
@@ -614,6 +642,7 @@ When creating or updating GitHub issues, use this structure:
    - Known pain points
 
 8. **🗺️ Impact Map**
+
    ```
    | Area | Change | Notes |
    |------|--------|-------|
@@ -640,6 +669,7 @@ When creating or updating GitHub issues, use this structure:
       use
 
 12. **🧰 Commands to Run Before PR**
+
     ```bash
     npm run lint
     npm test
@@ -667,10 +697,10 @@ When creating or updating GitHub issues, use this structure:
     - Who to ask + preferred channel
     - Clarification etiquette and response SLA
 
-**Optional Section (if backend involved):**
-18. **🔌 Backend Integration**: API endpoints, data models, auth
+**Optional Section (if backend involved):** 18. **🔌 Backend Integration**: API endpoints, data models, auth
 
 **Quality Requirements:**
+
 - Character budget: ≤15k (ideal ≤12k)
 - **Precise file:line references** for all code mentions
 - **Concrete test code examples** (not vague descriptions)
@@ -682,6 +712,7 @@ When creating or updating GitHub issues, use this structure:
 - **Focus on implementation playbook** (not PM overhead)
 
 **Quality Rubric (Pass/Needs Work):**
+
 - ✓ Clarity: Mid-level dev can start without extra context
 - ✓ Completeness: All sections filled with actionable info
 - ✓ Decisions: Architecture/product decisions documented
@@ -699,6 +730,7 @@ When creating or updating GitHub issues, use this structure:
 **Required for**: `/sw:analyse-issue`, `/sw:create-issue`
 
 When analyzing issues:
+
 1. Read issue description and all comments
 2. Check for attachments (download if needed)
 3. Reference related issues/PRs if mentioned
@@ -708,6 +740,7 @@ When analyzing issues:
 7. Output structured analysis with file:line references
 
 **Multi-Perspective Analysis** (for `/sw:analyse-issue`):
+
 - Collect three Spec Cards in parallel:
   - **Quick Win** (minimal path, reuse, effort estimate)
   - **Quality** (patterns, cleanup, abstractions)
@@ -727,6 +760,7 @@ When analyzing issues:
 `/sw:coder-simple`
 
 When implementing features:
+
 1. Read issue documentation completely
 2. Extract code quality standards (Section 3)
 3. Extract testing strategy (Section 3: Testing Strategy for
@@ -744,6 +778,7 @@ When implementing features:
 8. Create PR — CI/CD runs the full test suite automatically
 
 **Quality Gates Before PR (targeted only):**
+
 <!--
 Customize using commands from Testing Strategy for Agents:
 - [ ] Code formatted (changed files)
@@ -756,6 +791,7 @@ Customize using commands from Testing Strategy for Agents:
 
 **Implementation State Recovery:**
 For `/sw:continue-implementation`, assess:
+
 - What was completed vs attempted
 - Which quality gates failed
 - Which tests are failing and why
@@ -766,6 +802,7 @@ For `/sw:continue-implementation`, assess:
 **Required for**: `/sw:pull-request-review`
 
 When reviewing PRs:
+
 1. Check all PR comments and requested changes
 2. Verify code follows quality standards (Section 3)
 3. Run tests locally if applicable
@@ -881,6 +918,7 @@ See Section 1 for resolved paths. Defaults: `[imports_root]/`,
   - Maintains original numbering for traceability
 
 **Task Template Structure:**
+
 <!--
 See: docs/TASK_TEMPLATE.md (if exists)
 
@@ -897,6 +935,7 @@ Default structure:
 -->
 
 **Agent Selection:**
+
 - `perplexity-web-research`: Complex reasoning, strategic analysis
 - `tavily-web-research`: Real-time data extraction, site mapping
 - `brave-web-research`: Broad web/news/video search (quota-aware)
@@ -904,6 +943,7 @@ Default structure:
 - `reference-search`: Fast internal reference lookup
 
 **Research Quality Standards:**
+
 - All claims cited with [Source](url) links
 - Markdown line length ≤80 characters
 - Clear section headers and structure
@@ -920,6 +960,7 @@ paths.
 Defaults: `[report_dir]/`, `[report_dir]/000-topic-reference.md`
 
 **When Updating or Maintaining Reports:**
+
 1. Read `000-topic-reference.md` to locate chapter ownership and tags
 2. Identify chapters requiring updates or new subsections
 3. Decide whether to extend an existing file or create a new numbered
@@ -936,6 +977,7 @@ Defaults: `[report_dir]/`, `[report_dir]/000-topic-reference.md`
    `[index_dir]/`
 
 **Report Quality Standards:**
+
 - Markdown line length ≤80 characters
 - YAML frontmatter present and taxonomy-compliant
 - Consistent heading levels with no orphaned sections
@@ -954,6 +996,7 @@ Defaults: `[imports_root]/new/`, `[imports_root]/converted/`,
 `[imports_root]/archived/`, `[references_dir]/`
 
 **When Ingesting Files:**
+
 1. Stage raw PDFs or markdown inside `[imports_root]/new/`
 2. Run `/utils:convert-pdf` for PDFs to generate intermediary markdown
    before import
@@ -989,20 +1032,24 @@ Defaults: `[imports_root]/new/`, `[imports_root]/converted/`,
 ### When Things Go Wrong
 
 **Workflow Interruption** (Ctrl+C):
+
 - State is saved in FlowState
 - Resume using continuation commands if available
 - Check last output in terminal for context
 
 **Command Failures**:
+
 - Review error output carefully
 - Check if reference documents changed
 - Verify tool availability and authentication
 - Report issue with full context if bug suspected
 
 **Merge Conflicts**:
+
 - [Your conflict resolution strategy]
 
 **Failed CI Checks**:
+
 - [Your CI failure handling process]
 
 ## 9. Custom Workflow Extensions

--- a/app/components/auth/LoginForm.vue
+++ b/app/components/auth/LoginForm.vue
@@ -2,15 +2,8 @@
   <form @submit.prevent="onSubmit">
     <ion-item>
       <ion-label position="stacked">{{ $t('auth.email') }}</ion-label>
-      <ion-input
-        v-model="email"
-        type="email"
-        :placeholder="$t('auth.enterEmail')"
-        required
-      />
-      <ion-note v-if="errors.email" color="danger">{{
-        errors.email
-      }}</ion-note>
+      <ion-input v-model="email" type="email" :placeholder="$t('auth.enterEmail')" required />
+      <ion-note v-if="errors.email" color="danger">{{ errors.email }}</ion-note>
     </ion-item>
 
     <ion-item>
@@ -21,9 +14,7 @@
         :placeholder="$t('auth.enterPassword')"
         required
       />
-      <ion-note v-if="errors.password" color="danger">{{
-        errors.password
-      }}</ion-note>
+      <ion-note v-if="errors.password" color="danger">{{ errors.password }}</ion-note>
     </ion-item>
 
     <div class="button-container">
@@ -46,10 +37,7 @@
 
 <script setup lang="ts">
 import type { LoginCredentials } from '../../../shared/types'
-import {
-  loginSchema,
-  useFormValidation
-} from '~/composables/validation/useFormValidation'
+import { loginSchema, useFormValidation } from '~/composables/validation/useFormValidation'
 
 interface Props {
   loading?: boolean
@@ -67,10 +55,10 @@ withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
-const { handleSubmit, defineField, errors, isValid } = useFormValidation(
-  loginSchema,
-  { email: '', password: '' }
-)
+const { handleSubmit, defineField, errors, isValid } = useFormValidation(loginSchema, {
+  email: '',
+  password: ''
+})
 
 const [email] = defineField('email' as const)
 const [password] = defineField('password' as const)

--- a/app/components/content/VideoCard.vue
+++ b/app/components/content/VideoCard.vue
@@ -82,6 +82,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { ContentPublic } from '../../../shared/types/api/content.types'
 
 interface Props {

--- a/app/components/content/VideoCard.vue
+++ b/app/components/content/VideoCard.vue
@@ -55,7 +55,11 @@
 
         <!-- Credits Badge -->
         <ion-badge :color="video.credits === 0 ? 'success' : 'primary'" class="credits-badge">
-          {{ video.credits === 0 ? t('video.free.badge') : `${video.credits} credits` }}
+          {{
+            video.credits === 0
+              ? t('video.free.badge')
+              : `${video.credits} ${t('tutorials.sort.credits')}`
+          }}
         </ion-badge>
       </div>
 

--- a/app/components/content/VideoCard.vue
+++ b/app/components/content/VideoCard.vue
@@ -54,26 +54,14 @@
         </ion-chip>
 
         <!-- Credits Badge -->
-        <ion-badge
-          :color="video.credits === 0 ? 'success' : 'primary'"
-          class="credits-badge"
-        >
-          {{
-            video.credits === 0
-              ? t('video.free.badge')
-              : `${video.credits} credits`
-          }}
+        <ion-badge :color="video.credits === 0 ? 'success' : 'primary'" class="credits-badge">
+          {{ video.credits === 0 ? t('video.free.badge') : `${video.credits} credits` }}
         </ion-badge>
       </div>
 
       <!-- Category Tags (first 3) -->
       <div class="chips-container">
-        <ion-chip
-          v-for="tag in video.category_tags.slice(0, 3)"
-          :key="tag"
-          size="small"
-          outline
-        >
+        <ion-chip v-for="tag in video.category_tags.slice(0, 3)" :key="tag" size="small" outline>
           <ion-label>{{ tag }}</ion-label>
         </ion-chip>
       </div>
@@ -104,9 +92,7 @@ const isValidVimeoUrl = computed(() => {
   if (!props.video.url) return false
   const directPattern = /^https:\/\/(?:www\.)?vimeo\.com\/\d+(?:\?.*)?$/
   const embedPattern = /^https:\/\/player\.vimeo\.com\/video\/\d+(?:\?.*)?$/
-  return (
-    directPattern.test(props.video.url) || embedPattern.test(props.video.url)
-  )
+  return directPattern.test(props.video.url) || embedPattern.test(props.video.url)
 })
 
 // Get color for level chip

--- a/app/components/help/HelpIcon.vue
+++ b/app/components/help/HelpIcon.vue
@@ -60,11 +60,7 @@ const { t } = useI18n()
 const { showHelp } = useHelp()
 const { helpCircleOutline } = useIcons()
 
-const translate = (
-  key: string,
-  fallback: string,
-  params?: Record<string, unknown>
-): string => {
+const translate = (key: string, fallback: string, params?: Record<string, unknown>): string => {
   const translated = params ? t(key, params) : t(key)
   return translated === key ? fallback : translated
 }
@@ -90,9 +86,7 @@ const ariaLabel: ComputedRef<string> = computed(() => {
 
   // Try to get specific help label for the topic
   const topicPath = props.topic
-  const specificLabel = topicPath
-    ? translate(`help.topics.${topicPath}.ariaLabel`, '')
-    : ''
+  const specificLabel = topicPath ? translate(`help.topics.${topicPath}.ariaLabel`, '') : ''
 
   if (specificLabel) {
     return specificLabel
@@ -103,11 +97,9 @@ const ariaLabel: ComputedRef<string> = computed(() => {
     ? translate(`help.topics.${topicPath}.title`, formatTopic(topicPath))
     : translate('help.button.genericTopic', 'topic')
 
-  return translate(
-    'help.button.ariaLabel',
-    `Get help for ${fallbackTopicTitle}`,
-    { topic: fallbackTopicTitle }
-  )
+  return translate('help.button.ariaLabel', `Get help for ${fallbackTopicTitle}`, {
+    topic: fallbackTopicTitle
+  })
 })
 
 /**

--- a/app/components/help/HelpModal.vue
+++ b/app/components/help/HelpModal.vue
@@ -6,11 +6,7 @@
           {{ currentTitle }}
         </ion-title>
         <ion-buttons slot="end">
-          <ion-button
-            fill="clear"
-            :aria-label="$t('common.close')"
-            @click="dismiss"
-          >
+          <ion-button fill="clear" :aria-label="$t('common.close')" @click="dismiss">
             <ion-icon :icon="closeIcon" />
           </ion-button>
         </ion-buttons>
@@ -45,10 +41,7 @@
         </ion-text>
 
         <!-- Sections if available -->
-        <div
-          v-if="helpContent.sections && helpContent.sections.length"
-          class="ion-margin-top"
-        >
+        <div v-if="helpContent.sections && helpContent.sections.length" class="ion-margin-top">
           <div
             v-for="(section, index) in helpContent.sections"
             :key="`section-${index}`"
@@ -105,9 +98,7 @@ const helpIcon = helpCircleOutline
 const availableTopics = Object.values(HelpTopic)
 
 // Selected topic state
-const selectedTopic: Ref<string> = ref(
-  props.topic || HelpTopic.GETTING_STARTED
-)
+const selectedTopic: Ref<string> = ref(props.topic || HelpTopic.GETTING_STARTED)
 
 // Show navigation only if no specific topic or multiple available
 const showTopicNavigation: ComputedRef<boolean> = computed(() => {

--- a/app/components/layout/PrivateFooter.vue
+++ b/app/components/layout/PrivateFooter.vue
@@ -8,11 +8,7 @@
       </ion-buttons>
 
       <ion-title size="small">
-        <a
-          href="https://www.mannainsect.com"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://www.mannainsect.com" target="_blank" rel="noopener noreferrer">
           {{ t('footer.poweredBy') }}
         </a>
       </ion-title>

--- a/app/components/layout/PrivateFooter.vue
+++ b/app/components/layout/PrivateFooter.vue
@@ -31,8 +31,8 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
+import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const { menu, home } = useIcons()

--- a/app/components/layout/PrivateFooter.vue
+++ b/app/components/layout/PrivateFooter.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
 
 const { t } = useI18n()

--- a/app/components/layout/PrivateHeader.vue
+++ b/app/components/layout/PrivateHeader.vue
@@ -4,12 +4,7 @@
       <ion-title class="title-left">{{ t('home.title') }}</ion-title>
 
       <ion-buttons slot="end">
-        <HelpIcon
-          v-if="currentTopic"
-          :topic="currentTopic"
-          size="large"
-          color="primary"
-        />
+        <HelpIcon v-if="currentTopic" :topic="currentTopic" size="large" color="primary" />
         <UiBaseLanguageSwitcher />
       </ion-buttons>
     </ion-toolbar>

--- a/app/components/layout/PrivateHeader.vue
+++ b/app/components/layout/PrivateHeader.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import HelpIcon from '~/components/help/HelpIcon.vue'
 import { useHelpTopic } from '~/composables/useHelpTopic'
 

--- a/app/components/layout/PrivateMenu.vue
+++ b/app/components/layout/PrivateMenu.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
 import { logOutOutline, personOutline } from 'ionicons/icons'
 

--- a/app/components/layout/PrivateMenu.vue
+++ b/app/components/layout/PrivateMenu.vue
@@ -21,8 +21,8 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
+import { useI18n } from 'vue-i18n'
 import { logOutOutline, personOutline } from 'ionicons/icons'
 
 const { t } = useI18n()

--- a/app/components/layout/PublicFooter.vue
+++ b/app/components/layout/PublicFooter.vue
@@ -8,11 +8,7 @@
       </ion-buttons>
 
       <ion-title size="small">
-        <a
-          href="https://www.mannainsect.com"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://www.mannainsect.com" target="_blank" rel="noopener noreferrer">
           {{ t('footer.poweredBy') }}
         </a>
       </ion-title>

--- a/app/components/layout/PublicFooter.vue
+++ b/app/components/layout/PublicFooter.vue
@@ -31,8 +31,8 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
+import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const { menu, home } = useIcons()

--- a/app/components/layout/PublicFooter.vue
+++ b/app/components/layout/PublicFooter.vue
@@ -31,6 +31,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
 
 const { t } = useI18n()

--- a/app/components/layout/PublicHeader.vue
+++ b/app/components/layout/PublicHeader.vue
@@ -4,12 +4,7 @@
       <ion-title class="title-left">{{ t('home.title') }}</ion-title>
 
       <ion-buttons slot="end">
-        <HelpIcon
-          v-if="currentTopic"
-          :topic="currentTopic"
-          size="large"
-          color="primary"
-        />
+        <HelpIcon v-if="currentTopic" :topic="currentTopic" size="large" color="primary" />
         <UiBaseLanguageSwitcher />
       </ion-buttons>
     </ion-toolbar>

--- a/app/components/layout/PublicHeader.vue
+++ b/app/components/layout/PublicHeader.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import HelpIcon from '~/components/help/HelpIcon.vue'
 import { useHelpTopic } from '~/composables/useHelpTopic'
 

--- a/app/components/layout/PublicMenu.vue
+++ b/app/components/layout/PublicMenu.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
 import { logInOutline, personAddOutline } from 'ionicons/icons'
 

--- a/app/components/layout/PublicMenu.vue
+++ b/app/components/layout/PublicMenu.vue
@@ -21,8 +21,8 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
 import { menuController } from '@ionic/vue'
+import { useI18n } from 'vue-i18n'
 import { logInOutline, personAddOutline } from 'ionicons/icons'
 
 const { t } = useI18n()

--- a/app/components/ui/ErrorCard.vue
+++ b/app/components/ui/ErrorCard.vue
@@ -12,6 +12,8 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 interface Props {
   message: string
   showRetry?: boolean

--- a/app/components/ui/base/BaseInput.vue
+++ b/app/components/ui/base/BaseInput.vue
@@ -17,12 +17,8 @@
       @ion-blur="handleBlur"
       @ion-focus="handleFocus"
     />
-    <ion-note v-if="hasError" slot="error" color="danger">{{
-      errorMessage
-    }}</ion-note>
-    <ion-note v-else-if="helpText" slot="helper" color="medium">{{
-      helpText
-    }}</ion-note>
+    <ion-note v-if="hasError" slot="error" color="danger">{{ errorMessage }}</ion-note>
+    <ion-note v-else-if="helpText" slot="helper" color="medium">{{ helpText }}</ion-note>
   </ion-item>
 </template>
 

--- a/app/components/ui/base/BaseSelect.vue
+++ b/app/components/ui/base/BaseSelect.vue
@@ -25,12 +25,8 @@
         {{ option.label }}
       </ion-select-option>
     </ion-select>
-    <ion-note v-if="hasError" slot="error" color="danger">{{
-      errorMessage
-    }}</ion-note>
-    <ion-note v-else-if="helpText" slot="helper" color="medium">{{
-      helpText
-    }}</ion-note>
+    <ion-note v-if="hasError" slot="error" color="danger">{{ errorMessage }}</ion-note>
+    <ion-note v-else-if="helpText" slot="helper" color="medium">{{ helpText }}</ion-note>
   </ion-item>
 </template>
 
@@ -76,9 +72,7 @@ const emit = defineEmits<Emits>()
 const { t } = useI18n()
 
 const hasError = computed(() => !!props.errorMessage)
-const resolvedPlaceholder = computed(
-  () => props.placeholder || t('forms.selectPlaceholder')
-)
+const resolvedPlaceholder = computed(() => props.placeholder || t('forms.selectPlaceholder'))
 
 const handleChange = (event: CustomEvent) => {
   emit('update:modelValue', event.detail.value)

--- a/app/components/ui/base/BaseSelect.vue
+++ b/app/components/ui/base/BaseSelect.vue
@@ -35,6 +35,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type { SelectOption } from '../../../../shared/types'
 
 interface Props {

--- a/app/components/ui/base/CountrySelector.vue
+++ b/app/components/ui/base/CountrySelector.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { computed, toRefs } from 'vue'
 import { useCountries } from '~/composables/useCountries'
 import type { Country } from '~/composables/useCountries'

--- a/app/components/ui/base/CountrySelector.vue
+++ b/app/components/ui/base/CountrySelector.vue
@@ -47,9 +47,7 @@ const { t } = useI18n()
 const { countries: availableCountries } = useCountries()
 
 const resolvedLabel = computed(() => props.label || t('forms.country'))
-const resolvedPlaceholder = computed(
-  () => props.placeholder || t('forms.countryPlaceholder')
-)
+const resolvedPlaceholder = computed(() => props.placeholder || t('forms.countryPlaceholder'))
 const countryOptions = computed<Country[]>(() => availableCountries.value)
 
 const handleChange = (event: CustomEvent) => {

--- a/app/components/ui/base/LanguageSwitcher.vue
+++ b/app/components/ui/base/LanguageSwitcher.vue
@@ -7,11 +7,7 @@
     :style="{ minWidth: '120px', maxWidth: '200px' }"
     @ion-change="changeLanguage"
   >
-    <ion-select-option
-      v-for="loc in availableLocales"
-      :key="loc.code"
-      :value="loc.code"
-    >
+    <ion-select-option v-for="loc in availableLocales" :key="loc.code" :value="loc.code">
       {{ loc.name }}
     </ion-select-option>
   </ion-select>
@@ -26,9 +22,7 @@ const currentLocale = ref(locale.value)
 const availableLocales = computed(() => locales.value)
 
 const currentLanguageName = computed(() => {
-  const current = availableLocales.value.find(
-    l => l.code === currentLocale.value
-  )
+  const current = availableLocales.value.find(l => l.code === currentLocale.value)
   return current?.name || t('common.language')
 })
 

--- a/app/components/ui/base/LanguageSwitcher.vue
+++ b/app/components/ui/base/LanguageSwitcher.vue
@@ -18,6 +18,8 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 const { locale, locales, t } = useI18n()
 const currentLocale = ref(locale.value)
 

--- a/app/components/ui/feedback/ErrorBoundary.vue
+++ b/app/components/ui/feedback/ErrorBoundary.vue
@@ -52,6 +52,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { warningOutline } from 'ionicons/icons'
 
 interface Props {

--- a/app/components/ui/feedback/ErrorBoundary.vue
+++ b/app/components/ui/feedback/ErrorBoundary.vue
@@ -14,16 +14,8 @@
           <p>{{ message || $t('errors.boundary.message') }}</p>
 
           <div v-if="showDetails && errorDetails" class="error-details">
-            <ion-button
-              fill="clear"
-              size="small"
-              @click="showErrorDetails = !showErrorDetails"
-            >
-              {{
-                showErrorDetails
-                  ? $t('common.hideDetails')
-                  : $t('common.showDetails')
-              }}
+            <ion-button fill="clear" size="small" @click="showErrorDetails = !showErrorDetails">
+              {{ showErrorDetails ? $t('common.hideDetails') : $t('common.showDetails') }}
             </ion-button>
 
             <div v-if="showErrorDetails" class="error-code">
@@ -36,12 +28,7 @@
               {{ retryText || $t('common.retry') }}
             </ion-button>
 
-            <ion-button
-              v-if="showGoHome"
-              fill="outline"
-              color="medium"
-              @click="goHome"
-            >
+            <ion-button v-if="showGoHome" fill="outline" color="medium" @click="goHome">
               {{ $t('common.goHome') }}
             </ion-button>
           </div>

--- a/app/components/ui/feedback/ErrorMessage.vue
+++ b/app/components/ui/feedback/ErrorMessage.vue
@@ -2,16 +2,9 @@
   <ion-card v-if="message" :color="color">
     <ion-card-content>
       <div class="ion-display-flex ion-align-items-start">
-        <ion-icon
-          v-if="showIcon"
-          :icon="warning"
-          :color="color"
-          class="ion-margin-end"
-        />
+        <ion-icon v-if="showIcon" :icon="warning" :color="color" class="ion-margin-end" />
         <div class="ion-flex">
-          <ion-card-title v-if="title" :color="color">{{
-            title
-          }}</ion-card-title>
+          <ion-card-title v-if="title" :color="color">{{ title }}</ion-card-title>
           <ion-text :color="color">
             <p class="ion-no-margin">{{ message }}</p>
           </ion-text>

--- a/app/components/ui/feedback/LoadingSpinner.vue
+++ b/app/components/ui/feedback/LoadingSpinner.vue
@@ -16,14 +16,7 @@
 
 <script setup lang="ts">
 interface Props {
-  name?:
-    | 'bubbles'
-    | 'circles'
-    | 'circular'
-    | 'crescent'
-    | 'dots'
-    | 'lines'
-    | 'lines-small'
+  name?: 'bubbles' | 'circles' | 'circular' | 'crescent' | 'dots' | 'lines' | 'lines-small'
   color?: string
   message?: string
   centered?: boolean

--- a/app/composables/api/repositories/AuthRepository.ts
+++ b/app/composables/api/repositories/AuthRepository.ts
@@ -47,9 +47,7 @@ export class AuthRepository extends BaseRepository {
   /**
    * Refresh access token
    */
-  async refreshToken(
-    refreshData: RefreshTokenRequest
-  ): Promise<RefreshTokenResponse> {
+  async refreshToken(refreshData: RefreshTokenRequest): Promise<RefreshTokenResponse> {
     return this.post<RefreshTokenResponse>('/auth/refresh', refreshData)
   }
 
@@ -66,10 +64,7 @@ export class AuthRepository extends BaseRepository {
   /**
    * Confirm password reset using new /auth/reset-password/confirm endpoint
    */
-  async confirmPasswordReset(
-    token: string,
-    newPassword: string
-  ): Promise<{ message: string }> {
+  async confirmPasswordReset(token: string, newPassword: string): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
     return this.post<{ message: string }>(endpoints.authResetPasswordConfirm, {
       token,

--- a/app/composables/api/repositories/BaseRepository.ts
+++ b/app/composables/api/repositories/BaseRepository.ts
@@ -49,30 +49,21 @@ export abstract class BaseRepository {
   /**
    * POST request helper
    */
-  protected async post<T = unknown>(
-    endpoint: string,
-    body?: unknown
-  ): Promise<T> {
+  protected async post<T = unknown>(endpoint: string, body?: unknown): Promise<T> {
     return this.request<T>(endpoint, { method: 'POST', body })
   }
 
   /**
    * PUT request helper
    */
-  protected async put<T = unknown>(
-    endpoint: string,
-    body?: unknown
-  ): Promise<T> {
+  protected async put<T = unknown>(endpoint: string, body?: unknown): Promise<T> {
     return this.request<T>(endpoint, { method: 'PUT', body })
   }
 
   /**
    * PATCH request helper
    */
-  protected async patch<T = unknown>(
-    endpoint: string,
-    body?: unknown
-  ): Promise<T> {
+  protected async patch<T = unknown>(endpoint: string, body?: unknown): Promise<T> {
     return this.request<T>(endpoint, { method: 'PATCH', body })
   }
 

--- a/app/composables/api/repositories/CompanyRepository.ts
+++ b/app/composables/api/repositories/CompanyRepository.ts
@@ -16,10 +16,7 @@ export class CompanyRepository extends BaseRepository {
    * PUT /companies/${companyId}
    * All fields are optional
    */
-  async updateCompany(
-    companyId: string,
-    data: UpdateCompanyRequest
-  ): Promise<Company> {
+  async updateCompany(companyId: string, data: UpdateCompanyRequest): Promise<Company> {
     const endpoints = useApiEndpoints()
     return this.put<Company>(`${endpoints.companies}/${companyId}`, data)
   }

--- a/app/composables/api/repositories/CreditRepository.ts
+++ b/app/composables/api/repositories/CreditRepository.ts
@@ -12,18 +12,9 @@ export class CreditRepository extends BaseRepository {
   /**
    * Get credits log for a user
    */
-  async getCredits(
-    params: GetCreditsRequest = {}
-  ): Promise<GetCreditsResponse> {
+  async getCredits(params: GetCreditsRequest = {}): Promise<GetCreditsResponse> {
     const endpoints = useApiEndpoints()
-    const {
-      user_id,
-      transaction_type,
-      start_date,
-      end_date,
-      page = 1,
-      limit = 20
-    } = params
+    const { user_id, transaction_type, start_date, end_date, page = 1, limit = 20 } = params
 
     const query = this.buildPaginationQuery(page, limit, {
       ...(user_id && { user_id }),
@@ -57,9 +48,7 @@ export class CreditRepository extends BaseRepository {
    */
   async getCreditBalance(): Promise<GetCreditBalanceResponse> {
     const endpoints = useApiEndpoints()
-    return this.get<GetCreditBalanceResponse>(
-      `${endpoints.logsCredits}/balance`
-    )
+    return this.get<GetCreditBalanceResponse>(`${endpoints.logsCredits}/balance`)
   }
 
   /**
@@ -69,13 +58,7 @@ export class CreditRepository extends BaseRepository {
     params: GetCreditsRequest = {}
   ): Promise<GetCreditTransactionsResponse> {
     const endpoints = useApiEndpoints()
-    const {
-      transaction_type,
-      start_date,
-      end_date,
-      page = 1,
-      limit = 20
-    } = params
+    const { transaction_type, start_date, end_date, page = 1, limit = 20 } = params
 
     const query = this.buildPaginationQuery(page, limit, {
       ...(transaction_type && { transaction_type }),
@@ -83,10 +66,7 @@ export class CreditRepository extends BaseRepository {
       ...(end_date && { end_date })
     })
 
-    return this.get<GetCreditTransactionsResponse>(
-      endpoints.logsCredits,
-      query
-    )
+    return this.get<GetCreditTransactionsResponse>(endpoints.logsCredits, query)
   }
 
   /**
@@ -96,9 +76,6 @@ export class CreditRepository extends BaseRepository {
     transactionData: CreateCreditTransactionRequest
   ): Promise<CreditTransaction> {
     const endpoints = useApiEndpoints()
-    return this.post<CreditTransaction>(
-      `${endpoints.logsCredits}/transactions`,
-      transactionData
-    )
+    return this.post<CreditTransaction>(`${endpoints.logsCredits}/transactions`, transactionData)
   }
 }

--- a/app/composables/api/repositories/LogRepository.ts
+++ b/app/composables/api/repositories/LogRepository.ts
@@ -14,15 +14,9 @@ export class LogRepository extends BaseRepository {
   /**
    * Get logs for a company with optional filters
    */
-  async getCompanyLogs(
-    companyId: string,
-    params?: GetLogsParams
-  ): Promise<PopulatedLog[]> {
+  async getCompanyLogs(companyId: string, params?: GetLogsParams): Promise<PopulatedLog[]> {
     const endpoints = useApiEndpoints()
-    const query: Record<
-      string,
-      string | number | boolean | string[] | number[]
-    > = {}
+    const query: Record<string, string | number | boolean | string[] | number[]> = {}
 
     if (params?.start_datetime) query.start_datetime = params.start_datetime
     if (params?.end_datetime) query.end_datetime = params.end_datetime
@@ -31,10 +25,7 @@ export class LogRepository extends BaseRepository {
     if (params?.deviceId) query.device_id = params.deviceId
     if (params?.log_type) query.log_type = params.log_type
 
-    return this.get<PopulatedLog[]>(
-      `${endpoints.logsCompany}/${companyId}`,
-      query
-    )
+    return this.get<PopulatedLog[]>(`${endpoints.logsCompany}/${companyId}`, query)
   }
 
   /**
@@ -58,10 +49,7 @@ export class LogRepository extends BaseRepository {
     params?: CreateContentLogParams
   ): Promise<CreateLogResponse> {
     const endpoints = useApiEndpoints()
-    const query: Record<
-      string,
-      string | number | boolean | string[] | number[]
-    > = {}
+    const query: Record<string, string | number | boolean | string[] | number[]> = {}
 
     if (params?.content_id) query.content_id = params.content_id
     if (params?.content_type) query.content_type = params.content_type
@@ -82,9 +70,7 @@ export class LogRepository extends BaseRepository {
    */
   async getCreditLogs(userId: string): Promise<GetCreditLogsResponse> {
     const endpoints = useApiEndpoints()
-    return this.get<GetCreditLogsResponse>(
-      `${endpoints.logsCredits}/${userId}`
-    )
+    return this.get<GetCreditLogsResponse>(`${endpoints.logsCredits}/${userId}`)
   }
 
   /**
@@ -96,10 +82,9 @@ export class LogRepository extends BaseRepository {
     endDate?: string
   ): Promise<PopulatedLog[]> {
     const endpoints = useApiEndpoints()
-    const query: Record<
-      string,
-      string | number | boolean | string[] | number[]
-    > = { device_id: deviceId }
+    const query: Record<string, string | number | boolean | string[] | number[]> = {
+      device_id: deviceId
+    }
 
     if (startDate) query.start_datetime = startDate
     if (endDate) query.end_datetime = endDate

--- a/app/composables/api/repositories/MetricsRepository.ts
+++ b/app/composables/api/repositories/MetricsRepository.ts
@@ -1,8 +1,5 @@
 import { BaseRepository } from './BaseRepository'
-import type {
-  MetricData,
-  MetricsResponse
-} from '../../../../shared/types/models/metrics'
+import type { MetricData, MetricsResponse } from '../../../../shared/types/models/metrics'
 
 export class MetricsRepository extends BaseRepository {
   /**

--- a/app/composables/api/repositories/ProfileRepository.ts
+++ b/app/composables/api/repositories/ProfileRepository.ts
@@ -1,9 +1,4 @@
-import type {
-  User,
-  Company,
-  ProfileMetrics,
-  CompanyTask
-} from '../../../../shared/types'
+import type { User, Company, ProfileMetrics, CompanyTask } from '../../../../shared/types'
 import { BaseRepository } from './BaseRepository'
 
 export interface ProfileResponse {

--- a/app/composables/api/repositories/UserRepository.ts
+++ b/app/composables/api/repositories/UserRepository.ts
@@ -32,9 +32,7 @@ export class UserRepository extends BaseRepository {
   /**
    * Get list of users with pagination and filters
    */
-  async getUsers(
-    searchParams: UserSearchRequest = {}
-  ): Promise<GetUsersResponse> {
+  async getUsers(searchParams: UserSearchRequest = {}): Promise<GetUsersResponse> {
     const endpoints = useApiEndpoints()
     const {
       page = 1,
@@ -74,10 +72,7 @@ export class UserRepository extends BaseRepository {
   /**
    * Update user profile
    */
-  async updateUser(
-    id: string | number,
-    userData: UpdateUserRequest
-  ): Promise<UpdateUserResponse> {
+  async updateUser(id: string | number, userData: UpdateUserRequest): Promise<UpdateUserResponse> {
     const endpoints = useApiEndpoints()
     return this.put<UpdateUserResponse>(`${endpoints.users}/${id}`, userData)
   }
@@ -85,9 +80,7 @@ export class UserRepository extends BaseRepository {
   /**
    * Update current user profile
    */
-  async updateCurrentUser(
-    userData: UpdateUserRequest
-  ): Promise<UpdateUserResponse> {
+  async updateCurrentUser(userData: UpdateUserRequest): Promise<UpdateUserResponse> {
     const endpoints = useApiEndpoints()
     const authStore = useAuthStore()
     const userId = authStore.user?.id || authStore.user?._id
@@ -96,10 +89,7 @@ export class UserRepository extends BaseRepository {
       throw new Error('User ID not found')
     }
 
-    return this.put<UpdateUserResponse>(
-      `${endpoints.users}/${userId}`,
-      userData
-    )
+    return this.put<UpdateUserResponse>(`${endpoints.users}/${userId}`, userData)
   }
 
   /**
@@ -113,15 +103,10 @@ export class UserRepository extends BaseRepository {
   /**
    * Switch active company for current user
    */
-  async switchCompany(
-    companyId: string | number
-  ): Promise<{ user: User; message: string }> {
+  async switchCompany(companyId: string | number): Promise<{ user: User; message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ user: User; message: string }>(
-      endpoints.profilesSwitchCompany,
-      {
-        company_id: companyId
-      }
-    )
+    return this.post<{ user: User; message: string }>(endpoints.profilesSwitchCompany, {
+      company_id: companyId
+    })
   }
 }

--- a/app/composables/api/services/LogService.ts
+++ b/app/composables/api/services/LogService.ts
@@ -159,8 +159,6 @@ export class LogService {
    */
   isValidLogType(logType: string): boolean {
     const validTypes = Object.values(LogType)
-    return (
-      validTypes.includes(logType as LogType) || logType.startsWith('custom_')
-    )
+    return validTypes.includes(logType as LogType) || logType.startsWith('custom_')
   }
 }

--- a/app/composables/api/services/MetricsService.ts
+++ b/app/composables/api/services/MetricsService.ts
@@ -1,8 +1,5 @@
 import { MetricsRepository } from '../repositories/MetricsRepository'
-import type {
-  MetricData,
-  MetricsResponse
-} from '../../../../shared/types/models/metrics'
+import type { MetricData, MetricsResponse } from '../../../../shared/types/models/metrics'
 
 export class MetricsService {
   private metricsRepository: MetricsRepository

--- a/app/composables/api/services/UserService.ts
+++ b/app/composables/api/services/UserService.ts
@@ -26,9 +26,7 @@ export class UserService {
 
     // Check if user data is available
     if (!this.authStore.user) {
-      throw new Error(
-        'User data not available. Please ensure you are logged in.'
-      )
+      throw new Error('User data not available. Please ensure you are logged in.')
     }
 
     return {

--- a/app/composables/api/utils/errorHandler.ts
+++ b/app/composables/api/utils/errorHandler.ts
@@ -20,11 +20,7 @@ export function handleApiError(
   context: string,
   options: ErrorHandlerOptions = {}
 ): string {
-  const {
-    defaultMessage = `Error ${context}`,
-    logError = true,
-    throwError = false
-  } = options
+  const { defaultMessage = `Error ${context}`, logError = true, throwError = false } = options
 
   let errorMessage: string
 

--- a/app/composables/auth/useLoginForm.ts
+++ b/app/composables/auth/useLoginForm.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import type { Ref } from 'vue'
 
 export interface LoginCredentials {

--- a/app/composables/auth/useRegistration.ts
+++ b/app/composables/auth/useRegistration.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import type { Ref } from 'vue'
 
 export interface RegistrationData {

--- a/app/composables/auth/useRegistration.ts
+++ b/app/composables/auth/useRegistration.ts
@@ -31,9 +31,7 @@ export function useRegistration(): UseRegistrationReturn {
    */
   const generateDefaultName = (email: string): string => {
     const emailPrefix = email.split('@')[0] || email
-    return emailPrefix
-      .replace(/[._-]/g, ' ')
-      .replace(/\b\w/g, l => l.toUpperCase())
+    return emailPrefix.replace(/[._-]/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
   }
 
   /**
@@ -49,10 +47,7 @@ export function useRegistration(): UseRegistrationReturn {
    * @param email - User's email address
    * @param password - User's password
    */
-  const registerUser = async (
-    email: string,
-    password: string
-  ): Promise<void> => {
+  const registerUser = async (email: string, password: string): Promise<void> => {
     loading.value = true
     error.value = ''
 

--- a/app/composables/errors/useErrorHandler.ts
+++ b/app/composables/errors/useErrorHandler.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import type { FetchError } from 'ofetch'
 import type {
   ErrorInput,

--- a/app/composables/errors/useErrorHandler.ts
+++ b/app/composables/errors/useErrorHandler.ts
@@ -1,10 +1,6 @@
 import { useI18n } from 'vue-i18n'
 import type { FetchError } from 'ofetch'
-import type {
-  ErrorInput,
-  AppError as BaseAppError,
-  AppErrorDetails
-} from '../../../shared/types'
+import type { ErrorInput, AppError as BaseAppError, AppErrorDetails } from '../../../shared/types'
 
 // Extend the base AppError to ensure required fields for error handling
 interface AppError extends BaseAppError {
@@ -18,22 +14,12 @@ export function useErrorHandler() {
 
   // Type guard for FetchError
   const isFetchError = (error: unknown): error is FetchError => {
-    return (
-      error !== null &&
-      typeof error === 'object' &&
-      ('data' in error || 'statusCode' in error)
-    )
+    return error !== null && typeof error === 'object' && ('data' in error || 'statusCode' in error)
   }
 
   // Type guard for validation errors
-  const isValidationError = (
-    error: unknown
-  ): error is { issues?: unknown; errors?: unknown } => {
-    return (
-      error !== null &&
-      typeof error === 'object' &&
-      ('issues' in error || 'errors' in error)
-    )
+  const isValidationError = (error: unknown): error is { issues?: unknown; errors?: unknown } => {
+    return error !== null && typeof error === 'object' && ('issues' in error || 'errors' in error)
   }
 
   // Type guard for standard Error
@@ -97,11 +83,7 @@ export function useErrorHandler() {
       source?: string
     } = {}
   ) => {
-    const {
-      toast: showToast = true,
-      console: logToConsole = true,
-      source
-    } = options
+    const { toast: showToast = true, console: logToConsole = true, source } = options
     const normalizedError = normalizeError(error)
 
     // Log to console in development

--- a/app/composables/examples/useLogExample.ts
+++ b/app/composables/examples/useLogExample.ts
@@ -15,10 +15,7 @@ export const useActivityLogger = () => {
   /**
    * Log page views
    */
-  const logPageView = async (
-    pageName: string,
-    metadata?: Record<string, unknown>
-  ) => {
+  const logPageView = async (pageName: string, metadata?: Record<string, unknown>) => {
     await logUserAction('page_view', pageName, {
       ...metadata,
       timestamp: new Date().toISOString()
@@ -127,8 +124,7 @@ export const useProcessLogger = () => {
  * Example: Viewing logs with filters
  */
 export const useLogViewer = () => {
-  const { getLogs, setLogFilters, clearLogFilters, logs, loading, error } =
-    useLog()
+  const { getLogs, setLogFilters, clearLogFilters, logs, loading, error } = useLog()
 
   /**
    * Get logs for today

--- a/app/composables/useAccount.ts
+++ b/app/composables/useAccount.ts
@@ -19,13 +19,9 @@ export const useAccount = () => {
   const authRepository = new AuthRepository()
 
   // Computed
-  const hasCredits = computed(
-    () => user.value?.credits_balance && user.value.credits_balance > 0
-  )
+  const hasCredits = computed(() => user.value?.credits_balance && user.value.credits_balance > 0)
   const currentBalance = computed(() => user.value?.credits_balance || 0)
-  const purchasedProducts = computed(
-    () => user.value?.purchased_products || []
-  )
+  const purchasedProducts = computed(() => user.value?.purchased_products || [])
 
   // User Profile Methods
   const loadCurrentUser = async () => {
@@ -36,14 +32,9 @@ export const useAccount = () => {
       // Use centralized profile data from auth store
       const authStore = useAuthStore()
       await authStore.ensureProfileData() // Uses cached data or fetches if needed
-      user.value = authStore.user
-        ? JSON.parse(JSON.stringify(authStore.user))
-        : null
+      user.value = authStore.user ? JSON.parse(JSON.stringify(authStore.user)) : null
     } catch (err: unknown) {
-      error.value =
-        err instanceof Error
-          ? err.message
-          : t('errors.account.loadProfileFailed')
+      error.value = err instanceof Error ? err.message : t('errors.account.loadProfileFailed')
       console.error(t('errors.account.loadProfileLog'), err)
     } finally {
       isLoading.value = false
@@ -66,10 +57,7 @@ export const useAccount = () => {
 
       return response
     } catch (err: unknown) {
-      error.value =
-        err instanceof Error
-          ? err.message
-          : t('errors.account.updateProfileFailed')
+      error.value = err instanceof Error ? err.message : t('errors.account.updateProfileFailed')
       console.error(t('errors.account.updateProfileLog'), err)
       throw err
     } finally {
@@ -106,10 +94,7 @@ export const useAccount = () => {
       const response = await authRepository.sendPasswordReset(email)
       return response
     } catch (err: unknown) {
-      error.value =
-        err instanceof Error
-          ? err.message
-          : t('errors.account.sendResetFailed')
+      error.value = err instanceof Error ? err.message : t('errors.account.sendResetFailed')
       console.error(t('errors.account.sendResetLog'), err)
       throw err
     } finally {
@@ -117,24 +102,15 @@ export const useAccount = () => {
     }
   }
 
-  const resetPassword = async (
-    currentPassword: string,
-    newPassword: string
-  ) => {
+  const resetPassword = async (currentPassword: string, newPassword: string) => {
     try {
       isLoading.value = true
       error.value = ''
 
-      const response = await authRepository.resetUserPassword(
-        currentPassword,
-        newPassword
-      )
+      const response = await authRepository.resetUserPassword(currentPassword, newPassword)
       return response
     } catch (err: unknown) {
-      error.value =
-        err instanceof Error
-          ? err.message
-          : t('errors.account.resetPasswordFailed')
+      error.value = err instanceof Error ? err.message : t('errors.account.resetPasswordFailed')
       console.error(t('errors.account.resetPasswordLog'), err)
       throw err
     } finally {

--- a/app/composables/useAccount.ts
+++ b/app/composables/useAccount.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { ref, computed, readonly } from 'vue'
 import type { User, UpdateUserRequest, Credit } from '../../shared/types'
 import { UserRepository } from './api/repositories/UserRepository'

--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -46,8 +46,7 @@ export const useApi = () => {
       console.error('Network error:', error)
       throw createError({
         statusCode: 500,
-        statusMessage:
-          'Network connection error. Please check your internet connection.'
+        statusMessage: 'Network connection error. Please check your internet connection.'
       })
     }
   })

--- a/app/composables/useCompanyEdit.ts
+++ b/app/composables/useCompanyEdit.ts
@@ -36,22 +36,16 @@ export const useCompanyEdit = () => {
 
   // Form fields
   const { value: name, errorMessage: nameError } = useField<string>('name')
-  const { value: street, errorMessage: streetError } =
-    useField<string>('street')
+  const { value: street, errorMessage: streetError } = useField<string>('street')
   const { value: city, errorMessage: cityError } = useField<string>('city')
-  const { value: country, errorMessage: countryError } =
-    useField<string>('country')
-  const { value: timezone, errorMessage: timezoneError } =
-    useField<string>('timezone')
-  const { value: business_id, errorMessage: businessIdError } =
-    useField<string>('business_id')
+  const { value: country, errorMessage: countryError } = useField<string>('country')
+  const { value: timezone, errorMessage: timezoneError } = useField<string>('timezone')
+  const { value: business_id, errorMessage: businessIdError } = useField<string>('business_id')
 
   // Computed values
   const isValid = computed(() => form.meta.value.valid)
   const isDirty = computed(() => form.meta.value.dirty)
-  const hasErrors = computed(
-    () => !form.meta.value.valid && form.meta.value.touched
-  )
+  const hasErrors = computed(() => !form.meta.value.valid && form.meta.value.touched)
 
   // Check permissions
   const canEdit = computed(() => isCompanyAdmin() || isCompanyManager())
@@ -117,9 +111,7 @@ export const useCompanyEdit = () => {
 
     if (!canEdit.value) {
       error.value = t('account.company.permissionDenied')
-      await toast.showError(
-        error.value || t('account.company.permissionDenied')
-      )
+      await toast.showError(error.value || t('account.company.permissionDenied'))
       return
     }
 
@@ -131,14 +123,10 @@ export const useCompanyEdit = () => {
 
       // Only send changed fields
       const updateData: UpdateCompanyRequest = {}
-      if (formData.name !== activeCompany.value.name)
-        updateData.name = formData.name
-      if (formData.street !== activeCompany.value.street)
-        updateData.street = formData.street
-      if (formData.city !== activeCompany.value.city)
-        updateData.city = formData.city
-      if (formData.country !== activeCompany.value.country)
-        updateData.country = formData.country
+      if (formData.name !== activeCompany.value.name) updateData.name = formData.name
+      if (formData.street !== activeCompany.value.street) updateData.street = formData.street
+      if (formData.city !== activeCompany.value.city) updateData.city = formData.city
+      if (formData.country !== activeCompany.value.country) updateData.country = formData.country
       if (formData.timezone !== activeCompany.value.timezone)
         updateData.timezone = formData.timezone
       if (formData.business_id !== activeCompany.value.business_id)
@@ -165,8 +153,7 @@ export const useCompanyEdit = () => {
       isEditing.value = false
     } catch (err: unknown) {
       console.error(t('errors.account.updateCompanyLog'), err)
-      error.value =
-        err instanceof Error ? err.message : t('account.company.updateError')
+      error.value = err instanceof Error ? err.message : t('account.company.updateError')
 
       await toast.showError(error.value || t('common.error'))
     } finally {

--- a/app/composables/useCompanyEdit.ts
+++ b/app/composables/useCompanyEdit.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'
 import { createCompanyEditSchema } from '~/utils/validation/companySchemas'

--- a/app/composables/useCompanyInitialization.ts
+++ b/app/composables/useCompanyInitialization.ts
@@ -78,20 +78,14 @@ export const useCompanyInitialization = () => {
         // Company created successfully
 
         if (response.failed_space_types?.length) {
-          console.warn(
-            '[CompanyInit] Some spaces failed to create:',
-            response.failed_space_types
-          )
+          console.warn('[CompanyInit] Some spaces failed to create:', response.failed_space_types)
         }
       }
 
       return response
     } catch (error) {
       // Use the error handler for consistent error handling
-      const normalizedError = handleApiError(
-        error as Error,
-        'CompanyInit: Create company'
-      )
+      const normalizedError = handleApiError(error as Error, 'CompanyInit: Create company')
       throw normalizedError
     }
   }
@@ -132,10 +126,7 @@ export const useCompanyInitialization = () => {
       } catch (error) {
         lastError = error as Error
         // Use silent error handler for retry attempts
-        handleSilentError(
-          error as Error,
-          `CompanyInit: Attempt ${attempts} failed`
-        )
+        handleSilentError(error as Error, `CompanyInit: Attempt ${attempts} failed`)
 
         if (attempts < maxRetries) {
           // Exponential backoff: 1s, 2s, 4s

--- a/app/composables/useCountries.ts
+++ b/app/composables/useCountries.ts
@@ -9,11 +9,9 @@ export const useCountries = () => {
   const { t, locale } = useI18n()
 
   const localizedCountries = computed<Country[]>(() => {
-    const rawLocale =
-      typeof locale.value === 'string' ? locale.value.trim() : ''
+    const rawLocale = typeof locale.value === 'string' ? locale.value.trim() : ''
     const normalizedLocale = rawLocale.replace(/_/g, '-')
-    const candidateLocale =
-      normalizedLocale.length > 0 ? normalizedLocale : 'en-US'
+    const candidateLocale = normalizedLocale.length > 0 ? normalizedLocale : 'en-US'
 
     let displayNames: Intl.DisplayNames | null = null
     for (const localeCode of [candidateLocale, 'en-US']) {

--- a/app/composables/useCountries.ts
+++ b/app/composables/useCountries.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { computed } from 'vue'
 import type { Country } from '~/utils/countries'
 import { COUNTRIES_DATA, POPULAR_COUNTRY_CODES } from '~/utils/countries'

--- a/app/composables/useCurrencyExchange.ts
+++ b/app/composables/useCurrencyExchange.ts
@@ -40,9 +40,7 @@ export const useCurrencyExchange = () => {
     }
   }
 
-  const fetchRateWithCache = async (
-    currency: string
-  ): Promise<number | null> => {
+  const fetchRateWithCache = async (currency: string): Promise<number | null> => {
     try {
       // Check cache first
       const cached = getCachedRate(currency)

--- a/app/composables/useHelp.ts
+++ b/app/composables/useHelp.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { modalController } from '@ionic/vue'
 import type { Ref } from 'vue'
 import { ref, onUnmounted, getCurrentInstance } from 'vue'

--- a/app/composables/useHelp.ts
+++ b/app/composables/useHelp.ts
@@ -21,11 +21,7 @@ let previousActiveElement: HTMLElement | null = null
 export const useHelp = () => {
   const { t } = useI18n()
 
-  const translate = (
-    key: string,
-    fallback: string,
-    params?: Record<string, unknown>
-  ): string => {
+  const translate = (key: string, fallback: string, params?: Record<string, unknown>): string => {
     const translated = params ? t(key, params) : t(key)
     return translated === key ? fallback : translated
   }
@@ -33,10 +29,7 @@ export const useHelp = () => {
   // Fallback content for missing topics
   const getFallbackContent = () => ({
     title: translate('help.fallback.title', 'Help'),
-    content: translate(
-      'help.fallback.content',
-      'Help content is not available for this topic.'
-    ),
+    content: translate('help.fallback.content', 'Help content is not available for this topic.'),
     sections: []
   })
 
@@ -69,8 +62,7 @@ export const useHelp = () => {
    */
   const saveScrollPosition = (): void => {
     try {
-      savedScrollPosition =
-        window.pageYOffset || document.documentElement.scrollTop
+      savedScrollPosition = window.pageYOffset || document.documentElement.scrollTop
       console.debug('[useHelp] Saved scroll position:', savedScrollPosition)
     } catch (error) {
       console.warn('[useHelp] Failed to save scroll position:', error)
@@ -84,10 +76,7 @@ export const useHelp = () => {
     try {
       if (savedScrollPosition > 0) {
         window.scrollTo(0, savedScrollPosition)
-        console.debug(
-          '[useHelp] Restored scroll position:',
-          savedScrollPosition
-        )
+        console.debug('[useHelp] Restored scroll position:', savedScrollPosition)
         savedScrollPosition = 0
       }
     } catch (error) {
@@ -101,10 +90,7 @@ export const useHelp = () => {
   const saveFocus = (): void => {
     try {
       previousActiveElement = document.activeElement as HTMLElement
-      console.debug(
-        '[useHelp] Saved focus element:',
-        previousActiveElement?.tagName ?? ''
-      )
+      console.debug('[useHelp] Saved focus element:', previousActiveElement?.tagName ?? '')
     } catch (error) {
       console.warn('[useHelp] Failed to save focus:', error)
     }
@@ -117,10 +103,7 @@ export const useHelp = () => {
     try {
       if (previousActiveElement && previousActiveElement.focus) {
         previousActiveElement.focus()
-        console.debug(
-          '[useHelp] Restored focus to:',
-          previousActiveElement.tagName
-        )
+        console.debug('[useHelp] Restored focus to:', previousActiveElement.tagName)
         previousActiveElement = null
       }
     } catch (error) {
@@ -231,10 +214,7 @@ export const useHelp = () => {
 
       // Performance warning
       if (loadTime > 200) {
-        console.warn(
-          '[useHelp] Modal took longer than 200ms to open:',
-          `${formattedLoadTime}ms`
-        )
+        console.warn('[useHelp] Modal took longer than 200ms to open:', `${formattedLoadTime}ms`)
       }
     } catch (error) {
       console.error('[useHelp] Error showing help modal:', error)

--- a/app/composables/useHelpTopic.ts
+++ b/app/composables/useHelpTopic.ts
@@ -28,11 +28,9 @@ export const useHelpTopic = () => {
     // Also check locale-suffixed route names (e.g., market___es)
     const cleanRouteName = routeName.replace(/___[a-z]{2,3}(-[A-Z]{2})?$/, '')
 
-    if (cleanPath === '/' || cleanRouteName === 'index')
-      return HelpTopic.GETTING_STARTED
+    if (cleanPath === '/' || cleanRouteName === 'index') return HelpTopic.GETTING_STARTED
 
-    if (cleanPath === '/main' || cleanRouteName === 'main')
-      return HelpTopic.GETTING_STARTED
+    if (cleanPath === '/main' || cleanRouteName === 'main') return HelpTopic.GETTING_STARTED
 
     if (cleanPath === '/account' || cleanPath.startsWith('/account?'))
       return HelpTopic.PROFILE_SETTINGS

--- a/app/composables/useI18n.ts
+++ b/app/composables/useI18n.ts
@@ -1,3 +1,5 @@
+import { useI18n } from 'vue-i18n'
+
 export const useAppI18n = () => {
   const { $i18n } = useNuxtApp()
   const i18n = useI18n()

--- a/app/composables/useI18n.ts
+++ b/app/composables/useI18n.ts
@@ -23,12 +23,9 @@ export const useAppI18n = () => {
 
   const switchLanguage = async (locale: string) => {
     try {
-      await navigateTo(
-        localePath(route.path, locale as 'en' | 'es' | 'fr' | 'de' | 'pt'),
-        {
-          replace: true
-        }
-      )
+      await navigateTo(localePath(route.path, locale as 'en' | 'es' | 'fr' | 'de' | 'pt'), {
+        replace: true
+      })
     } catch (error) {
       console.warn('Failed to switch language:', error)
       // Fallback to setting locale without navigation
@@ -37,10 +34,7 @@ export const useAppI18n = () => {
   }
 
   const getLocalizedRoute = (route: string, locale?: string) => {
-    return localePath(
-      route,
-      locale as 'en' | 'es' | 'fr' | 'de' | 'pt' | undefined
-    )
+    return localePath(route, locale as 'en' | 'es' | 'fr' | 'de' | 'pt' | undefined)
   }
 
   return {

--- a/app/composables/useLog.ts
+++ b/app/composables/useLog.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { LogService } from './api/services/LogService'
 import type { PopulatedLog, LogFilters } from '../../shared/types/models/log'
 import type { CreateLogResponse } from '../../shared/types/api/log'

--- a/app/composables/useLog.ts
+++ b/app/composables/useLog.ts
@@ -25,10 +25,7 @@ export const useLog = () => {
   /**
    * Get logs for the current company
    */
-  const getLogs = async (
-    startDate?: string,
-    endDate?: string
-  ): Promise<PopulatedLog[]> => {
+  const getLogs = async (startDate?: string, endDate?: string): Promise<PopulatedLog[]> => {
     loading.value = true
     error.value = ''
     requestErrors.value = []
@@ -135,8 +132,7 @@ export const useLog = () => {
       return response
     } catch (err: unknown) {
       const e = err as Error & { data?: { detail?: string } }
-      const errorMessage =
-        e.data?.detail || e.message || t('errors.fetchCreditLogs')
+      const errorMessage = e.data?.detail || e.message || t('errors.fetchCreditLogs')
       error.value = errorMessage
       requestErrors.value = [errorMessage]
       handleError(err, { source: 'useLog.getCreditLogs' })
@@ -157,12 +153,7 @@ export const useLog = () => {
     options?: { throwOnError?: boolean }
   ) => {
     try {
-      await logService.createContentLog(
-        contentId,
-        contentType,
-        action,
-        additionalData
-      )
+      await logService.createContentLog(contentId, contentType, action, additionalData)
     } catch (err: unknown) {
       if (options?.throwOnError) {
         throw err

--- a/app/composables/useMetrics.ts
+++ b/app/composables/useMetrics.ts
@@ -59,13 +59,8 @@ export const useMetrics = () => {
       // Determine timeout based on connection quality
       let timeoutDuration = 3000 // Default 3s
       if (import.meta.client && 'connection' in navigator) {
-        const connection = (
-          navigator as Navigator & { connection?: NetworkInformation }
-        ).connection
-        if (
-          connection?.effectiveType === 'slow-2g' ||
-          connection?.effectiveType === '2g'
-        ) {
+        const connection = (navigator as Navigator & { connection?: NetworkInformation }).connection
+        if (connection?.effectiveType === 'slow-2g' || connection?.effectiveType === '2g') {
           timeoutDuration = 2000 // 2s for slow connections
         }
       }
@@ -114,10 +109,7 @@ export const useMetrics = () => {
   /**
    * Track a page view
    */
-  const trackPageView = async (
-    page: string,
-    additionalInfo?: Record<string, unknown>
-  ) => {
+  const trackPageView = async (page: string, additionalInfo?: Record<string, unknown>) => {
     const metricData: MetricData = {
       category: MetricCategory.PAGE_VIEW,
       extra_info: {
@@ -133,10 +125,7 @@ export const useMetrics = () => {
   /**
    * Track a button click
    */
-  const trackButtonClick = async (
-    buttonName: string,
-    additionalInfo?: Record<string, unknown>
-  ) => {
+  const trackButtonClick = async (buttonName: string, additionalInfo?: Record<string, unknown>) => {
     const metricData: MetricData = {
       category: MetricCategory.CLICK_BUTTON,
       extra_info: {
@@ -152,10 +141,7 @@ export const useMetrics = () => {
   /**
    * Track a feature usage
    */
-  const trackFeatureUsage = async (
-    feature: string,
-    additionalInfo?: Record<string, unknown>
-  ) => {
+  const trackFeatureUsage = async (feature: string, additionalInfo?: Record<string, unknown>) => {
     const metricData: MetricData = {
       category: MetricCategory.FEATURE_USED,
       extra_info: {

--- a/app/composables/useProfile.ts
+++ b/app/composables/useProfile.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { ProfileRepository } from './api/repositories/ProfileRepository'
 
 export const useProfile = () => {

--- a/app/composables/useProfileEdit.ts
+++ b/app/composables/useProfileEdit.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import { z } from 'zod'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'

--- a/app/composables/useProfileEdit.ts
+++ b/app/composables/useProfileEdit.ts
@@ -40,15 +40,12 @@ export const useProfileEdit = () => {
   // Form fields
   const { value: name, errorMessage: nameError } = useField<string>('name')
   const { value: city, errorMessage: cityError } = useField<string>('city')
-  const { value: country, errorMessage: countryError } =
-    useField<string>('country')
+  const { value: country, errorMessage: countryError } = useField<string>('country')
 
   // Computed values
   const isValid = computed(() => form.meta.value.valid)
   const isDirty = computed(() => form.meta.value.dirty)
-  const hasErrors = computed(
-    () => !form.meta.value.valid && form.meta.value.touched
-  )
+  const hasErrors = computed(() => !form.meta.value.valid && form.meta.value.touched)
 
   // Get all form errors
   const allErrors = computed(() => {
@@ -106,8 +103,7 @@ export const useProfileEdit = () => {
       const updateData: UpdateUserRequest = {}
       if (formData.name !== user.value.name) updateData.name = formData.name
       if (formData.city !== user.value.city) updateData.city = formData.city
-      if (formData.country !== user.value.country)
-        updateData.country = formData.country
+      if (formData.country !== user.value.country) updateData.country = formData.country
 
       // Only make API call if there are actual changes
       if (Object.keys(updateData).length === 0) {
@@ -132,8 +128,7 @@ export const useProfileEdit = () => {
       isEditing.value = false
     } catch (err: unknown) {
       console.error(t('errors.account.updateProfileLog'), err)
-      error.value =
-        err instanceof Error ? err.message : t('account.profile.updateError')
+      error.value = err instanceof Error ? err.message : t('account.profile.updateError')
 
       const toast = await useToast().create({
         message: error.value || t('common.error'),

--- a/app/composables/useSafeLocalePath.ts
+++ b/app/composables/useSafeLocalePath.ts
@@ -51,10 +51,7 @@ export const useSafeLocalePath = () => {
   /**
    * Generate cache key for path resolution
    */
-  const getCacheKey = (
-    route: RouteInput,
-    locale?: LocalePathOptions
-  ): string => {
+  const getCacheKey = (route: RouteInput, locale?: LocalePathOptions): string => {
     const routeStr = typeof route === 'string' ? route : JSON.stringify(route)
     const localeStr = locale || currentLocale?.value || 'default'
     return `${localeStr}:${routeStr}`
@@ -63,10 +60,7 @@ export const useSafeLocalePath = () => {
   /**
    * Fallback path resolution when localePath is not available
    */
-  const fallbackPathResolver = (
-    route: RouteInput,
-    locale?: LocalePathOptions
-  ): string => {
+  const fallbackPathResolver = (route: RouteInput, locale?: LocalePathOptions): string => {
     // Handle string routes
     if (typeof route === 'string') {
       const targetLocale = locale || currentLocale?.value || 'en'
@@ -110,10 +104,7 @@ export const useSafeLocalePath = () => {
   /**
    * Main function to get localized path with fallback and caching
    */
-  const safeLocalePath = (
-    route: RouteInput,
-    locale?: LocalePathOptions
-  ): string => {
+  const safeLocalePath = (route: RouteInput, locale?: LocalePathOptions): string => {
     try {
       // Check cache first
       const cacheKey = getCacheKey(route, locale)

--- a/app/composables/useSafeLocalePath.ts
+++ b/app/composables/useSafeLocalePath.ts
@@ -1,3 +1,4 @@
+import { useI18n } from 'vue-i18n'
 import type { RouteLocationRaw } from 'vue-router'
 import type { Ref } from 'vue'
 

--- a/app/composables/useTextFormatting.ts
+++ b/app/composables/useTextFormatting.ts
@@ -84,11 +84,7 @@ export const useTextFormatting = () => {
 
       while ((match = markdownLinkRegex.exec(text)) !== null) {
         const [, linkText, url] = match
-        if (
-          linkText &&
-          url &&
-          (url.startsWith('http://') || url.startsWith('https://'))
-        ) {
+        if (linkText && url && (url.startsWith('http://') || url.startsWith('https://'))) {
           if (!seenUrls.has(url)) {
             seenUrls.add(url)
             links.push({

--- a/app/composables/useTimezones.ts
+++ b/app/composables/useTimezones.ts
@@ -1,8 +1,5 @@
 import { computed } from 'vue'
-import {
-  TIMEZONE_IDENTIFIERS,
-  POPULAR_TIMEZONE_VALUES
-} from '~/utils/timezones'
+import { TIMEZONE_IDENTIFIERS, POPULAR_TIMEZONE_VALUES } from '~/utils/timezones'
 
 export interface Timezone {
   value: string
@@ -51,9 +48,9 @@ export const useTimezones = () => {
   }
 
   const getPopularTimezones = (): Timezone[] => {
-    return POPULAR_TIMEZONE_VALUES.map(value =>
-      getTimezoneByValue(value)
-    ).filter((tz): tz is Timezone => tz !== undefined)
+    return POPULAR_TIMEZONE_VALUES.map(value => getTimezoneByValue(value)).filter(
+      (tz): tz is Timezone => tz !== undefined
+    )
   }
 
   return {

--- a/app/composables/useTranslation.ts
+++ b/app/composables/useTranslation.ts
@@ -60,11 +60,7 @@ export function useTranslation() {
   }
 
   // Generate cache key using hash or truncated text
-  function generateCacheKey(
-    text: string,
-    source: string,
-    target: string
-  ): string {
+  function generateCacheKey(text: string, source: string, target: string): string {
     // Create a simple hash of the text to avoid btoa Unicode issues
     let hash = 0
     for (let i = 0; i < text.length; i++) {
@@ -78,11 +74,7 @@ export function useTranslation() {
   }
 
   // Get cached translation
-  function getCachedTranslation(
-    text: string,
-    source: string,
-    target: string
-  ): string | null {
+  function getCachedTranslation(text: string, source: string, target: string): string | null {
     const cacheKey = generateCacheKey(text, source, target)
     const stored = localStorage.getItem(cacheKey)
     if (!stored) return null

--- a/app/composables/useUser.ts
+++ b/app/composables/useUser.ts
@@ -1,8 +1,4 @@
-import type {
-  CreateUserRequest,
-  UpdateUserRequest,
-  UserSearchRequest
-} from '../../shared/types'
+import type { CreateUserRequest, UpdateUserRequest, UserSearchRequest } from '../../shared/types'
 
 export const useUser = () => {
   const userService = useUserService()
@@ -24,10 +20,7 @@ export const useUser = () => {
     return userService.createUser(userData)
   }
 
-  const updateUser = async (
-    id: string | number,
-    userData: UpdateUserRequest
-  ) => {
+  const updateUser = async (id: string | number, userData: UpdateUserRequest) => {
     const result = await userService.updateUser(id, userData)
     // If updating current user, refresh profile
     if (String(id) === String(authStore.userId)) {

--- a/app/composables/useUserRole.ts
+++ b/app/composables/useUserRole.ts
@@ -111,9 +111,7 @@ export const useUserRole = () => {
     const roleData = getCachedRoleData()
     const admins = roleData.admins || []
 
-    return admins.some(
-      (admin: User) => admin._id === userId || admin.id === userId
-    )
+    return admins.some((admin: User) => admin._id === userId || admin.id === userId)
   }
 
   /**
@@ -130,9 +128,7 @@ export const useUserRole = () => {
     const roleData = getCachedRoleData()
     const managers = roleData.managers || []
 
-    return managers.some(
-      (manager: User) => manager._id === userId || manager.id === userId
-    )
+    return managers.some((manager: User) => manager._id === userId || manager.id === userId)
   }
 
   /**
@@ -149,9 +145,7 @@ export const useUserRole = () => {
     const roleData = getCachedRoleData()
     const operators = roleData.operators || []
 
-    return operators.some(
-      (operator: User) => operator._id === userId || operator.id === userId
-    )
+    return operators.some((operator: User) => operator._id === userId || operator.id === userId)
   }
 
   /**

--- a/app/composables/validation/useFormValidation.ts
+++ b/app/composables/validation/useFormValidation.ts
@@ -8,9 +8,7 @@ export const validationSchemas = {
   email: z.string().email('Please enter a valid email address'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
   required: z.string().min(1, 'This field is required'),
-  phone: z
-    .string()
-    .regex(/^\+?[\d\s\-()]+$/, 'Please enter a valid phone number'),
+  phone: z.string().regex(/^\+?[\d\s\-()]+$/, 'Please enter a valid phone number'),
   url: z.string().url('Please enter a valid URL')
 }
 
@@ -52,8 +50,7 @@ export function useFormValidation<T extends Record<string, unknown>>(
   initialValues?: Partial<T>
 ) {
   const form = useForm<T>({
-    validationSchema:
-      schema instanceof z.ZodType ? toTypedSchema(schema) : schema,
+    validationSchema: schema instanceof z.ZodType ? toTypedSchema(schema) : schema,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     initialValues: initialValues as any
   })

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -21,10 +21,7 @@ export default defineNuxtRouteMiddleware(async _to => {
     try {
       await authStore.ensureProfileData(true)
     } catch (error) {
-      console.error(
-        '[AUTH_MIDDLEWARE] Failed to bootstrap profile data:',
-        error
-      )
+      console.error('[AUTH_MIDDLEWARE] Failed to bootstrap profile data:', error)
 
       // If profile fetch fails critically, redirect to error page
       // Check if it's a network error or authentication issue

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -27,9 +27,7 @@
       <!-- Basic User Details -->
       <ion-card>
         <ion-card-header>
-          <ion-card-title>{{
-            $t('account.profile.basicDetails')
-          }}</ion-card-title>
+          <ion-card-title>{{ $t('account.profile.basicDetails') }}</ion-card-title>
         </ion-card-header>
         <ion-card-content>
           <div v-if="!isEditing">
@@ -55,10 +53,7 @@
               <ion-label>
                 <h3>{{ $t('account.profile.country') }}</h3>
                 <p>
-                  {{
-                    getCountryName(profileData?.country || '') ||
-                    $t('common.notSet')
-                  }}
+                  {{ getCountryName(profileData?.country || '') || $t('common.notSet') }}
                 </p>
               </ion-label>
             </ion-item>
@@ -105,9 +100,7 @@
             </ion-item>
 
             <ion-item lines="none" :class="{ 'ion-invalid': nameError }">
-              <ion-label position="stacked">
-                {{ $t('account.profile.name') }} *
-              </ion-label>
+              <ion-label position="stacked"> {{ $t('account.profile.name') }} * </ion-label>
               <ion-input
                 v-model="name"
                 :placeholder="$t('account.profile.namePlaceholder')"
@@ -122,10 +115,7 @@
               <ion-label position="stacked">
                 {{ $t('account.profile.city') }}
               </ion-label>
-              <ion-input
-                v-model="city"
-                :placeholder="$t('account.profile.cityPlaceholder')"
-              />
+              <ion-input v-model="city" :placeholder="$t('account.profile.cityPlaceholder')" />
             </ion-item>
 
             <ion-item lines="none">
@@ -156,11 +146,7 @@
                 :disabled="!isValid || isSubmitting"
                 color="primary"
               >
-                <ion-spinner
-                  v-if="isSubmitting"
-                  slot="start"
-                  name="crescent"
-                />
+                <ion-spinner v-if="isSubmitting" slot="start" name="crescent" />
                 {{ $t('common.save') }}
               </ion-button>
               <ion-button
@@ -224,10 +210,7 @@
               <ion-label>
                 <h3>{{ $t('account.company.country') }}</h3>
                 <p>
-                  {{
-                    getCountryName(activeCompany.country || '') ||
-                    $t('account.company.notSet')
-                  }}
+                  {{ getCountryName(activeCompany.country || '') || $t('account.company.notSet') }}
                 </p>
               </ion-label>
             </ion-item>
@@ -249,9 +232,7 @@
               <ion-label>
                 <h3>{{ $t('account.company.businessId') }}</h3>
                 <p>
-                  {{
-                    activeCompany.business_id || $t('account.company.notSet')
-                  }}
+                  {{ activeCompany.business_id || $t('account.company.notSet') }}
                 </p>
               </ion-label>
             </ion-item>
@@ -300,13 +281,8 @@
               </ion-item>
             </div>
 
-            <ion-item
-              lines="none"
-              :class="{ 'ion-invalid': companyNameError }"
-            >
-              <ion-label position="stacked">
-                {{ $t('account.company.name') }} *
-              </ion-label>
+            <ion-item lines="none" :class="{ 'ion-invalid': companyNameError }">
+              <ion-label position="stacked"> {{ $t('account.company.name') }} * </ion-label>
               <ion-input
                 v-model="companyName"
                 :placeholder="$t('account.company.namePlaceholder')"
@@ -393,11 +369,7 @@
                 :disabled="!isCompanyValid || isCompanySubmitting"
                 color="primary"
               >
-                <ion-spinner
-                  v-if="isCompanySubmitting"
-                  slot="start"
-                  name="crescent"
-                />
+                <ion-spinner v-if="isCompanySubmitting" slot="start" name="crescent" />
                 {{ $t('common.save') }}
               </ion-button>
               <ion-button
@@ -485,11 +457,7 @@
                   :disabled="passwordLoading || !isPasswordValid"
                   size="large"
                 >
-                  <ion-spinner
-                    v-if="passwordLoading"
-                    slot="start"
-                    name="crescent"
-                  />
+                  <ion-spinner v-if="passwordLoading" slot="start" name="crescent" />
                   {{ $t('account.password.updateButton') }}
                 </ion-button>
               </div>

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -502,6 +502,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { ref, onMounted, computed } from 'vue'
 // Use icons from the centralized useIcons composable
 const { alertCircle, create, warning, wallet } = useIcons()

--- a/app/pages/auth/verify-email.vue
+++ b/app/pages/auth/verify-email.vue
@@ -2,10 +2,7 @@
   <ion-grid class="ion-padding">
     <ion-row class="ion-justify-content-center">
       <ion-col size="12" size-sm="6" size-md="5">
-        <div
-          v-if="creatingCompany"
-          class="ion-text-center ion-padding-vertical"
-        >
+        <div v-if="creatingCompany" class="ion-text-center ion-padding-vertical">
           <ion-icon
             :icon="businessOutline"
             size="large"
@@ -22,12 +19,7 @@
         </div>
 
         <div v-else class="ion-text-center ion-padding-vertical">
-          <ion-spinner
-            v-if="!error"
-            name="crescent"
-            size="large"
-            color="primary"
-          />
+          <ion-spinner v-if="!error" name="crescent" size="large" color="primary" />
           <ion-icon v-else :icon="closeCircle" size="large" color="danger" />
           <ion-text>
             <h2 v-if="!error">
@@ -39,18 +31,11 @@
           </ion-text>
         </div>
 
-        <div
-          v-if="companyCreationError"
-          class="ion-text-center ion-margin-top"
-        >
+        <div v-if="companyCreationError" class="ion-text-center ion-margin-top">
           <ion-text color="danger">
             <p>{{ companyCreationError }}</p>
           </ion-text>
-          <ion-button
-            expand="block"
-            class="ion-margin-top"
-            @click="retryCompanyCreation"
-          >
+          <ion-button expand="block" class="ion-margin-top" @click="retryCompanyCreation">
             {{ $t('auth.retryCreation') }}
           </ion-button>
           <ion-button

--- a/app/pages/auth/verify-email.vue
+++ b/app/pages/auth/verify-email.vue
@@ -68,6 +68,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { useSafeLocalePath } from '~/composables/useSafeLocalePath'
 
 definePageMeta({

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -118,6 +118,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import 'swiper/css'
 import 'swiper/css/navigation'
 import 'swiper/css/pagination'

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -69,11 +69,7 @@
       </ion-row>
       <ion-row class="ion-justify-content-center featured-actions">
         <ion-col size="12" size-sm="8" size-md="6" size-lg="4">
-          <ion-button
-            :router-link="localePath('/tutorials')"
-            expand="block"
-            fill="outline"
-          >
+          <ion-button :router-link="localePath('/tutorials')" expand="block" fill="outline">
             {{ t('home.featuredVideo.viewAll') }}
           </ion-button>
         </ion-col>
@@ -222,9 +218,7 @@ onMounted(async () => {
   try {
     const videos = await api<ContentPublic[]>('/products/content/public')
     // Filter for free videos with URLs
-    const freeVideos = videos.filter(
-      v => v.url !== null && v.level === 'basic' && v.credits === 0
-    )
+    const freeVideos = videos.filter(v => v.url !== null && v.level === 'basic' && v.credits === 0)
     if (freeVideos.length > 0) {
       const idx = Math.floor(Math.random() * freeVideos.length)
       featuredVideo.value = freeVideos[idx] ?? null

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -11,11 +11,7 @@
           </ion-text>
         </div>
 
-        <AuthLoginForm
-          :loading="loading"
-          :error="error"
-          @submit="handleLogin"
-        />
+        <AuthLoginForm :loading="loading" :error="error" @submit="handleLogin" />
 
         <div class="ion-text-center ion-margin-top">
           <ion-text color="medium">

--- a/app/pages/main.vue
+++ b/app/pages/main.vue
@@ -46,17 +46,11 @@
                     :fill="item.fill"
                     :disabled="loading || navigationLoading"
                     :aria-label="$t(item.ariaLabel || item.label)"
-                    :aria-describedby="
-                      navigationError ? 'nav-error-message' : undefined
-                    "
+                    :aria-describedby="navigationError ? 'nav-error-message' : undefined"
                     :tabindex="index"
                     @click="handleNavigation(item.route)"
                   >
-                    <ion-icon
-                      slot="start"
-                      :icon="item.icon"
-                      :aria-hidden="true"
-                    />
+                    <ion-icon slot="start" :icon="item.icon" :aria-hidden="true" />
                     {{ $t(item.label) }}
                   </ion-button>
                 </ion-col>
@@ -134,8 +128,7 @@ const navigateToRoute = async (route: string) => {
     } catch (err) {
       console.error(t('errors.navigationErrorLog'), err)
       // Set error message for screen readers
-      const fallbackMessage =
-        err instanceof Error ? err.message : t('errors.navigationFailed')
+      const fallbackMessage = err instanceof Error ? err.message : t('errors.navigationFailed')
       navigationError.value = `${t('common.error')}: ${fallbackMessage}`
 
       // Clear error after 5 seconds
@@ -149,10 +142,7 @@ const navigateToRoute = async (route: string) => {
 }
 
 // Create debounced navigation handler
-const handleNavigation = debounce(
-  (...args: unknown[]) => navigateToRoute(args[0] as string),
-  300
-)
+const handleNavigation = debounce((...args: unknown[]) => navigateToRoute(args[0] as string), 300)
 
 onMounted(() => {
   ensureProfileData()

--- a/app/pages/main.vue
+++ b/app/pages/main.vue
@@ -82,6 +82,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { debounce } from '../utils/helpers'
 import { useSafeLocalePath } from '~/composables/useSafeLocalePath'
 

--- a/app/pages/register.vue
+++ b/app/pages/register.vue
@@ -11,11 +11,7 @@
           </ion-text>
         </div>
 
-        <AuthRegisterForm
-          :submitting="submitting"
-          :error="error"
-          @submit="handleSubmit"
-        />
+        <AuthRegisterForm :submitting="submitting" :error="error" @submit="handleSubmit" />
 
         <div class="ion-text-center ion-margin-top">
           <ion-text color="medium">

--- a/app/pages/tutorials.vue
+++ b/app/pages/tutorials.vue
@@ -201,6 +201,7 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import type {
   ContentPublic,
   CategoryTag,

--- a/app/pages/tutorials.vue
+++ b/app/pages/tutorials.vue
@@ -56,11 +56,7 @@
                 <ion-label>
                   {{ t('tutorials.filters.level') }}
                 </ion-label>
-                <ion-select
-                  v-model="selectedLevels"
-                  multiple
-                  interface="popover"
-                >
+                <ion-select v-model="selectedLevels" multiple interface="popover">
                   <ion-select-option value="basic">
                     {{ t('video.level.basic') }}
                   </ion-select-option>
@@ -78,16 +74,8 @@
                 <ion-label>
                   {{ t('tutorials.filters.categoryTags') }}
                 </ion-label>
-                <ion-select
-                  v-model="selectedCategoryTags"
-                  multiple
-                  interface="popover"
-                >
-                  <ion-select-option
-                    v-for="tag in availableCategoryTags"
-                    :key="tag"
-                    :value="tag"
-                  >
+                <ion-select v-model="selectedCategoryTags" multiple interface="popover">
+                  <ion-select-option v-for="tag in availableCategoryTags" :key="tag" :value="tag">
                     {{ tag }}
                   </ion-select-option>
                 </ion-select>
@@ -98,16 +86,8 @@
                 <ion-label>
                   {{ t('tutorials.filters.profileTags') }}
                 </ion-label>
-                <ion-select
-                  v-model="selectedProfileTags"
-                  multiple
-                  interface="popover"
-                >
-                  <ion-select-option
-                    v-for="tag in availableProfileTags"
-                    :key="tag"
-                    :value="tag"
-                  >
+                <ion-select v-model="selectedProfileTags" multiple interface="popover">
+                  <ion-select-option v-for="tag in availableProfileTags" :key="tag" :value="tag">
                     {{ tag }}
                   </ion-select-option>
                 </ion-select>
@@ -166,10 +146,7 @@
       </ion-row>
 
       <!-- Empty State -->
-      <ion-row
-        v-if="filteredVideos.length === 0"
-        class="ion-justify-content-center"
-      >
+      <ion-row v-if="filteredVideos.length === 0" class="ion-justify-content-center">
         <ion-col size="12" size-md="8" size-lg="6">
           <ion-card>
             <ion-card-content class="ion-text-center">
@@ -186,13 +163,7 @@
 
       <!-- Videos Grid -->
       <ion-row v-else>
-        <ion-col
-          v-for="video in filteredVideos"
-          :key="video._id"
-          size="12"
-          size-md="6"
-          size-lg="4"
-        >
+        <ion-col v-for="video in filteredVideos" :key="video._id" size="12" size-md="6" size-lg="4">
           <VideoCard :video="video" />
         </ion-col>
       </ion-row>
@@ -202,11 +173,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import type {
-  ContentPublic,
-  CategoryTag,
-  ProfileTag
-} from '../../shared/types/api/content.types'
+import type { ContentPublic, CategoryTag, ProfileTag } from '../../shared/types/api/content.types'
 
 definePageMeta({
   layout: 'public'
@@ -240,9 +207,7 @@ const availableCategoryTags = computed(() => {
 
 const availableProfileTags = computed(() => {
   const tags = new Set<ProfileTag>()
-  videos.value.forEach((v: ContentPublic) =>
-    v.profile_tags.forEach((t: ProfileTag) => tags.add(t))
-  )
+  videos.value.forEach((v: ContentPublic) => v.profile_tags.forEach((t: ProfileTag) => tags.add(t)))
   return Array.from(tags).sort()
 })
 
@@ -259,9 +224,7 @@ const filteredVideos = computed(() => {
   if (searchQuery.value) {
     const query = searchQuery.value.toLowerCase()
     filtered = filtered.filter(
-      v =>
-        v.title?.toLowerCase().includes(query) ||
-        v.description?.toLowerCase().includes(query)
+      v => v.title?.toLowerCase().includes(query) || v.description?.toLowerCase().includes(query)
     )
   }
 
@@ -273,18 +236,14 @@ const filteredVideos = computed(() => {
   // Category tags filter (OR logic)
   if (selectedCategoryTags.value.length > 0) {
     filtered = filtered.filter((v: ContentPublic) =>
-      v.category_tags.some((tag: CategoryTag) =>
-        selectedCategoryTags.value.includes(tag)
-      )
+      v.category_tags.some((tag: CategoryTag) => selectedCategoryTags.value.includes(tag))
     )
   }
 
   // Profile tags filter (OR logic)
   if (selectedProfileTags.value.length > 0) {
     filtered = filtered.filter((v: ContentPublic) =>
-      v.profile_tags.some((tag: ProfileTag) =>
-        selectedProfileTags.value.includes(tag)
-      )
+      v.profile_tags.some((tag: ProfileTag) => selectedProfileTags.value.includes(tag))
     )
   }
 

--- a/app/pages/verify-token.vue
+++ b/app/pages/verify-token.vue
@@ -3,24 +3,14 @@
     <ion-row class="ion-justify-content-center">
       <ion-col size="12" size-sm="6" size-md="5" size-lg="5">
         <!-- Email verification step -->
-        <div
-          v-if="!creatingCompany"
-          class="ion-text-center ion-padding-vertical"
-        >
-          <ion-icon
-            :icon="mail"
-            size="large"
-            color="primary"
-            class="ion-margin-bottom"
-          />
+        <div v-if="!creatingCompany" class="ion-text-center ion-padding-vertical">
+          <ion-icon :icon="mail" size="large" color="primary" class="ion-margin-bottom" />
           <ion-text>
             <h1>{{ $t('auth.checkYourEmail') }}</h1>
           </ion-text>
           <ion-text color="medium">
             <p>
-              {{
-                $t('auth.verificationCodeSent', { email: registrationEmail })
-              }}
+              {{ $t('auth.verificationCodeSent', { email: registrationEmail }) }}
             </p>
           </ion-text>
         </div>
@@ -76,18 +66,11 @@
         </form>
 
         <!-- Retry button for company creation failures -->
-        <div
-          v-if="companyCreationError"
-          class="ion-text-center ion-margin-top"
-        >
+        <div v-if="companyCreationError" class="ion-text-center ion-margin-top">
           <ion-text color="danger">
             <p>{{ companyCreationError }}</p>
           </ion-text>
-          <ion-button
-            expand="block"
-            class="ion-margin-top"
-            @click="retryCompanyCreation"
-          >
+          <ion-button expand="block" class="ion-margin-top" @click="retryCompanyCreation">
             {{ $t('auth.retryCreation') }}
           </ion-button>
           <ion-button

--- a/app/pages/verify-token.vue
+++ b/app/pages/verify-token.vue
@@ -114,6 +114,8 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
 definePageMeta({
   middleware: 'guest'
 })

--- a/app/plugins/swiper.client.ts
+++ b/app/plugins/swiper.client.ts
@@ -5,9 +5,6 @@ export default defineNuxtPlugin(async () => {
     // Register Swiper custom elements globally
     register()
   } catch (error) {
-    console.warn(
-      'Swiper element bundle not found, skipping registration:',
-      error
-    )
+    console.warn('Swiper element bundle not found, skipping registration:', error)
   }
 })

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -13,12 +13,8 @@ export const useAuthStore = defineStore('auth', () => {
 
   // Computed properties for easy ID access
   const userId = computed(() => user.value?._id || user.value?.id)
-  const companyId = computed(
-    () => activeCompany.value?._id || activeCompany.value?.id
-  )
-  const otherCompanyIds = computed(() =>
-    otherCompanies.value.map(c => c._id || c.id)
-  )
+  const companyId = computed(() => activeCompany.value?._id || activeCompany.value?.id)
+  const otherCompanyIds = computed(() => otherCompanies.value.map(c => c._id || c.id))
   const userEmail = computed(() => user.value?.email)
   const userCredits = computed(() => user.value?.balance || 0)
 
@@ -80,9 +76,7 @@ export const useAuthStore = defineStore('auth', () => {
     const savedUser = storage.get<string>('auth_user')
     const savedActiveCompany = storage.get<string>('auth_active_company')
     const savedOtherCompanies = storage.get<string>('auth_other_companies')
-    const savedLastProfileFetch = storage.get<string>(
-      'auth_last_profile_fetch'
-    )
+    const savedLastProfileFetch = storage.get<string>('auth_last_profile_fetch')
 
     if (savedToken) {
       token.value = savedToken
@@ -132,9 +126,7 @@ export const useAuthStore = defineStore('auth', () => {
    * @param entity - Entity with potential id/_id fields
    * @returns Normalized entity with both id and _id fields
    */
-  const normalizeEntity = <T extends { _id?: string; id?: string | number }>(
-    entity: T
-  ): T => {
+  const normalizeEntity = <T extends { _id?: string; id?: string | number }>(entity: T): T => {
     if (!entity) return entity
     // Ensure both id and _id are present for backward compatibility
     if (entity._id && !entity.id) {
@@ -149,9 +141,7 @@ export const useAuthStore = defineStore('auth', () => {
   /**
    * Normalize arrays of entities
    */
-  const normalizeEntityArray = <
-    T extends { _id?: string; id?: string | number }
-  >(
+  const normalizeEntityArray = <T extends { _id?: string; id?: string | number }>(
     entities: T[]
   ): T[] => {
     if (!Array.isArray(entities)) return []
@@ -175,9 +165,7 @@ export const useAuthStore = defineStore('auth', () => {
     setActiveCompany(normalizedActiveCompany)
 
     // Normalize and set other companies
-    const normalizedOtherCompanies = normalizeEntityArray(
-      profile.other_companies || []
-    )
+    const normalizedOtherCompanies = normalizeEntityArray(profile.other_companies || [])
     setOtherCompanies(normalizedOtherCompanies)
 
     // Store role information if present
@@ -187,19 +175,13 @@ export const useAuthStore = defineStore('auth', () => {
         const storage = useStorage()
         const roleData = JSON.stringify({
           admins: normalizeEntityArray(profile.active_company.admins || []),
-          managers: normalizeEntityArray(
-            profile.active_company.managers || []
-          ),
-          operators: normalizeEntityArray(
-            profile.active_company.operators || []
-          )
+          managers: normalizeEntityArray(profile.active_company.managers || []),
+          operators: normalizeEntityArray(profile.active_company.operators || [])
         })
 
         // Check if data size is reasonable (< 100KB)
         if (roleData.length > 100000) {
-          console.warn(
-            '[AUTH] Role data too large for localStorage, storing summary only'
-          )
+          console.warn('[AUTH] Role data too large for localStorage, storing summary only')
           // Store only IDs if data is too large
           const summaryData = JSON.stringify({
             admins: (profile.active_company.admins || [])
@@ -220,9 +202,7 @@ export const useAuthStore = defineStore('auth', () => {
         // Handle localStorage errors (quota exceeded, disabled, etc.)
         if (error instanceof Error) {
           if (error.name === 'QuotaExceededError') {
-            console.error(
-              '[AUTH] localStorage quota exceeded, clearing old data'
-            )
+            console.error('[AUTH] localStorage quota exceeded, clearing old data')
             try {
               const storage = useStorage()
               // Clear old data to make room
@@ -261,9 +241,7 @@ export const useAuthStore = defineStore('auth', () => {
    * @throws Error if profile fetch fails after retries
    */
   const fetchProfile = async () => {
-    const { ProfileRepository } = await import(
-      '../composables/api/repositories/ProfileRepository'
-    )
+    const { ProfileRepository } = await import('../composables/api/repositories/ProfileRepository')
 
     // If there's already a fetch in progress, return the existing promise
     if (profileFetchPromise.value) {
@@ -280,17 +258,12 @@ export const useAuthStore = defineStore('auth', () => {
         const profile = await profileRepository.getCurrentProfile()
 
         // Auto-select first company if no active_company is set
-        if (
-          !profile.active_company?.company &&
-          profile.other_companies?.length > 0
-        ) {
+        if (!profile.active_company?.company && profile.other_companies?.length > 0) {
           // No active company found, auto-selecting first available
 
           // Get the first company ID (handle both _id and id fields)
           const firstCompany = profile.other_companies[0]
-          const firstCompanyId = firstCompany
-            ? firstCompany._id || firstCompany.id
-            : null
+          const firstCompanyId = firstCompany ? firstCompany._id || firstCompany.id : null
 
           if (!firstCompanyId) {
             console.error('[AUTH] First company has no valid ID')
@@ -319,8 +292,7 @@ export const useAuthStore = defineStore('auth', () => {
               // Using local fallback for company selection
               // Manually construct the active_company structure
               const activeCompanyId =
-                firstCompany?._id ??
-                (firstCompany?.id != null ? String(firstCompany.id) : null)
+                firstCompany?._id ?? (firstCompany?.id != null ? String(firstCompany.id) : null)
               const fallbackProfile: import('../composables/api/repositories/ProfileRepository').ProfileResponse =
                 {
                   ...profile,
@@ -338,14 +310,10 @@ export const useAuthStore = defineStore('auth', () => {
                     managers: [],
                     operators: []
                   },
-                  other_companies: (profile.other_companies || []).filter(
-                    other => {
-                      const otherId =
-                        other._id ??
-                        (other.id != null ? String(other.id) : null)
-                      return !activeCompanyId || otherId !== activeCompanyId
-                    }
-                  )
+                  other_companies: (profile.other_companies || []).filter(other => {
+                    const otherId = other._id ?? (other.id != null ? String(other.id) : null)
+                    return !activeCompanyId || otherId !== activeCompanyId
+                  })
                 }
               console.log('[AUTH] Using local fallback for company selection')
               setProfileState(fallbackProfile)

--- a/app/tests/product-translation.test.ts
+++ b/app/tests/product-translation.test.ts
@@ -38,10 +38,7 @@ describe('Product Detail Translation', () => {
       count: 11, // Over the limit of 10
       resetTime: Date.now() + 3600000 // 1 hour from now
     }
-    localStorage.setItem(
-      'user_translation_limit',
-      JSON.stringify(rateLimitEntry)
-    )
+    localStorage.setItem('user_translation_limit', JSON.stringify(rateLimitEntry))
 
     // Try to translate
     try {

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -4,10 +4,7 @@ export const formatDate = (date: Date | string, locale = 'en-US'): string => {
   return d.toLocaleDateString(locale)
 }
 
-export const formatDateTime = (
-  date: Date | string,
-  locale = 'en-US'
-): string => {
+export const formatDateTime = (date: Date | string, locale = 'en-US'): string => {
   const d = typeof date === 'string' ? new Date(date) : date
   return d.toLocaleString(locale)
 }
@@ -32,11 +29,7 @@ export const formatNumber = (num: number, locale = 'en-US'): string => {
   return num.toLocaleString(locale)
 }
 
-export const formatCurrency = (
-  amount: number,
-  currency = 'USD',
-  locale = 'en-US'
-): string => {
+export const formatCurrency = (amount: number, currency = 'USD', locale = 'en-US'): string => {
   return new Intl.NumberFormat(locale, {
     style: 'currency',
     currency

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -38,10 +38,7 @@ export const sortBy = <T>(
 }
 
 // Object utilities
-export const pick = <T extends object, K extends keyof T>(
-  obj: T,
-  keys: K[]
-): Pick<T, K> => {
+export const pick = <T extends object, K extends keyof T>(obj: T, keys: K[]): Pick<T, K> => {
   const result = {} as Pick<T, K>
   keys.forEach(key => {
     if (key in obj) {
@@ -51,10 +48,7 @@ export const pick = <T extends object, K extends keyof T>(
   return result
 }
 
-export const omit = <T extends object, K extends keyof T>(
-  obj: T,
-  keys: K[]
-): Omit<T, K> => {
+export const omit = <T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> => {
   const result = { ...obj }
   keys.forEach(key => {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
@@ -105,11 +99,7 @@ export const delay = (ms: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
-export const retry = async <T>(
-  fn: () => Promise<T>,
-  retries = 3,
-  delayMs = 1000
-): Promise<T> => {
+export const retry = async <T>(fn: () => Promise<T>, retries = 3, delayMs = 1000): Promise<T> => {
   try {
     return await fn()
   } catch (error) {
@@ -137,8 +127,7 @@ export const buildUrl = (
 
 // Random utilities
 export const generateId = (length = 8): string => {
-  const chars =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
   let result = ''
   for (let i = 0; i < length; i++) {
     result += chars.charAt(Math.floor(Math.random() * chars.length))
@@ -173,10 +162,7 @@ export const isValidRegex = (pattern: string): boolean => {
   }
 }
 
-export const createSafeRegex = (
-  pattern: string,
-  flags = ''
-): RegExp | null => {
+export const createSafeRegex = (pattern: string, flags = ''): RegExp | null => {
   try {
     // Check for ReDoS patterns (catastrophic backtracking)
     // Only check for truly dangerous nested quantifiers

--- a/app/utils/translatedConstants.ts
+++ b/app/utils/translatedConstants.ts
@@ -1,4 +1,4 @@
-import { useI18n } from '#imports'
+import { useI18n } from 'vue-i18n'
 
 export function getTranslatedUnits() {
   const { t } = useI18n()

--- a/app/utils/validation/companySchemas.ts
+++ b/app/utils/validation/companySchemas.ts
@@ -2,11 +2,7 @@ import { z } from 'zod'
 
 export const createCompanyEditSchema = (t: (key: string) => string) =>
   z.object({
-    name: z
-      .string()
-      .min(1, t('validation.company.nameRequired'))
-      .max(200)
-      .optional(),
+    name: z.string().min(1, t('validation.company.nameRequired')).max(200).optional(),
     street: z.string().max(200).optional(),
     city: z.string().max(100).optional(),
     country: z

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -93,8 +93,8 @@ tests/             # Vitest unit suites and Playwright E2E specs
   - Embed: `https://player.vimeo.com/video/{VIDEO_ID}`
   - Query parameters: Supported (e.g., `?badge=0&autopause=0`)
 - Security requirements enforced: HTTPS only, vimeo.com domains only,
-  iframe sandbox attributes (`allow-scripts allow-same-origin
-allow-presentation`).
+  iframe sandbox attributes
+  (`allow-scripts allow-same-origin allow-presentation`).
 - Use links directly in `<iframe src>`, no extra parsing or
   `@vimeo/player` dependency needed.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -94,7 +94,7 @@ tests/             # Vitest unit suites and Playwright E2E specs
   - Query parameters: Supported (e.g., `?badge=0&autopause=0`)
 - Security requirements enforced: HTTPS only, vimeo.com domains only,
   iframe sandbox attributes (`allow-scripts allow-same-origin
-  allow-presentation`).
+allow-presentation`).
 - Use links directly in `<iframe src>`, no extra parsing or
   `@vimeo/player` dependency needed.
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,10 +12,7 @@ export default createConfigForNuxt({
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/explicit-function-return-type': 'off',
       // Temporary: Allow legacy unused vars (19 instances)
-      '@typescript-eslint/no-unused-vars': [
-        'warn',
-        { argsIgnorePattern: '^_' }
-      ],
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
       // Temporary: Allow legacy dynamic delete (11 instances)
       '@typescript-eslint/no-dynamic-delete': 'warn',
       // Temporary: Allow legacy unsafe function types
@@ -52,6 +49,7 @@ export default createConfigForNuxt({
       '**/ios/**',
       '**/android/**',
       '**/.output/**',
-      '**/coverage/**'
+      '**/coverage/**',
+      '**/.claude/**'
     ]
   })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -52,13 +52,7 @@ export default defineNuxtConfig({
       ]
     }
   },
-  modules: [
-    '@nuxtjs/ionic',
-    '@pinia/nuxt',
-    '@vite-pwa/nuxt',
-    '@vueuse/nuxt',
-    '@nuxtjs/i18n'
-  ],
+  modules: ['@nuxtjs/ionic', '@pinia/nuxt', '@vite-pwa/nuxt', '@vueuse/nuxt', '@nuxtjs/i18n'],
   ionic: {
     integrations: {
       icons: true,

--- a/scripts/generate-pwa-icons.js
+++ b/scripts/generate-pwa-icons.js
@@ -39,11 +39,7 @@ async function generateIcons() {
     }
 
     // Also create favicon.ico (multi-size)
-    await baseIcon
-      .clone()
-      .resize(32, 32)
-      .png()
-      .toFile(path.join(publicDir, 'favicon-32x32.png'))
+    await baseIcon.clone().resize(32, 32).png().toFile(path.join(publicDir, 'favicon-32x32.png'))
 
     // All icons generated successfully!
   } catch (error) {

--- a/shared/types/api/credit.types.ts
+++ b/shared/types/api/credit.types.ts
@@ -1,17 +1,12 @@
 import type { ApiResponse, PaginatedResponse } from './common.types'
-import type {
-  Credit,
-  CreditBalance,
-  CreditTransaction
-} from '../models/Credit'
+import type { Credit, CreditBalance, CreditTransaction } from '../models/Credit'
 
 // Credit API response types
 export type GetCreditsResponse = PaginatedResponse<Credit>
 
 export type GetCreditBalanceResponse = ApiResponse<CreditBalance>
 
-export type GetCreditTransactionsResponse =
-  PaginatedResponse<CreditTransaction>
+export type GetCreditTransactionsResponse = PaginatedResponse<CreditTransaction>
 
 // Credit API request types
 export interface GetCreditsRequest {

--- a/shared/types/api/user.types.ts
+++ b/shared/types/api/user.types.ts
@@ -1,8 +1,4 @@
-import type {
-  User,
-  UpdateUserRequest,
-  UpdateUserResponse
-} from '../models/User'
+import type { User, UpdateUserRequest, UpdateUserResponse } from '../models/User'
 import type { PaginatedResponse } from './common.types'
 
 // User API endpoint types

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -25,25 +25,13 @@ export type * from './utils/form.types'
 export * from './help'
 
 // Re-export commonly used types for convenience
-export type {
-  LoginRequest,
-  LoginResponse,
-  RegisterRequest
-} from './api/auth.types'
+export type { LoginRequest, LoginResponse, RegisterRequest } from './api/auth.types'
 export type { User } from './models/User'
 export type { Company } from './models/Company'
 export type { Credit, CreditBalance, CreditTransaction } from './models/Credit'
 export type { Log, PopulatedLog, LogType, LogFilters } from './models/log'
-export type {
-  CreateLogRequest,
-  CreateLogResponse,
-  GetLogsResponse
-} from './api/log'
-export type {
-  ApiResponse,
-  ApiError,
-  PaginatedResponse
-} from './api/common.types'
+export type { CreateLogRequest, CreateLogResponse, GetLogsResponse } from './api/log'
+export type { ApiResponse, ApiError, PaginatedResponse } from './api/common.types'
 export type {
   ContentPublic,
   Content,

--- a/shared/types/models/log.ts
+++ b/shared/types/models/log.ts
@@ -21,8 +21,7 @@ export interface Log {
 /**
  * Log with populated relations (returned from GET endpoints)
  */
-export interface PopulatedLog
-  extends Omit<Log, 'user' | 'company' | 'space' | 'device'> {
+export interface PopulatedLog extends Omit<Log, 'user' | 'company' | 'space' | 'device'> {
   user?:
     | {
         _id: string

--- a/shared/types/utils/form.types.ts
+++ b/shared/types/utils/form.types.ts
@@ -18,9 +18,7 @@ export interface FormState<T extends Record<string, unknown>> {
 
 // Validation types
 export type ValidatorFn<T = unknown> = (value: T) => string | null
-export type AsyncValidatorFn<T = unknown> = (
-  value: T
-) => Promise<string | null>
+export type AsyncValidatorFn<T = unknown> = (value: T) => Promise<string | null>
 
 export interface ValidationRule<T = unknown> {
   validator: ValidatorFn<T> | AsyncValidatorFn<T>

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -5,19 +5,13 @@ test.describe('Homepage', () => {
     await page.waitForLoadState('networkidle')
     const heading = page.locator('h1')
     await expect(heading).toBeVisible()
-    await expect(heading).toHaveText(
-      /Launch secure account experiences faster/i
-    )
+    await expect(heading).toHaveText(/Launch secure account experiences faster/i)
   })
 
   test('should show authentication actions', async ({ page }) => {
     await page.goto('/')
-    const registerButton = page.locator(
-      'a[href="/register"], button:has-text("Get Started")'
-    )
-    const loginButton = page.locator(
-      'a[href="/login"], button:has-text("Sign In")'
-    )
+    const registerButton = page.locator('a[href="/register"], button:has-text("Get Started")')
+    const loginButton = page.locator('a[href="/login"], button:has-text("Sign In")')
     await expect(registerButton).toBeVisible()
     await expect(loginButton).toBeVisible()
   })

--- a/tests/e2e/video-display.spec.ts
+++ b/tests/e2e/video-display.spec.ts
@@ -24,9 +24,7 @@ test.describe('Video Display - Homepage', () => {
     }
   })
 
-  test('should display featured video with query parameters', async ({
-    page
-  }) => {
+  test('should display featured video with query parameters', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(1000)
@@ -46,9 +44,7 @@ test.describe('Video Display - Homepage', () => {
     }
   })
 
-  test('should have correct security attributes on iframe', async ({
-    page
-  }) => {
+  test('should have correct security attributes on iframe', async ({ page }) => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(1000)

--- a/tests/fixtures/videos.ts
+++ b/tests/fixtures/videos.ts
@@ -16,8 +16,7 @@ export const freeVideoWithQueryParams: ContentPublic = {
   profile_tags: ['newbie'],
   category_tags: ['breeding'],
   url:
-    'https://player.vimeo.com/video/1076142559?badge=0&' +
-    'autopause=0&player_id=0&app_id=58479',
+    'https://player.vimeo.com/video/1076142559?badge=0&' + 'autopause=0&player_id=0&app_id=58479',
   active: true,
   expiry_days: 0,
   created_at: '2025-01-01T00:00:00Z',

--- a/tests/setup/ionic-stubs.ts
+++ b/tests/setup/ionic-stubs.ts
@@ -19,14 +19,7 @@ export const ionicStubs = {
       ':maxlength="maxlength" ' +
       ':disabled="disabled" ' +
       ':rows="rows"></textarea>',
-    props: [
-      'modelValue',
-      'placeholder',
-      'disabled',
-      'maxlength',
-      'rows',
-      'autoGrow'
-    ],
+    props: ['modelValue', 'placeholder', 'disabled', 'maxlength', 'rows', 'autoGrow'],
     emits: ['update:modelValue', 'keydown']
   },
   'ion-input': {

--- a/tests/setup/test-setup.ts
+++ b/tests/setup/test-setup.ts
@@ -20,13 +20,7 @@ import {
   toRefs,
   shallowRef
 } from 'vue'
-import {
-  defineStore,
-  createPinia,
-  setActivePinia,
-  getActivePinia,
-  storeToRefs
-} from 'pinia'
+import { defineStore, createPinia, setActivePinia, getActivePinia, storeToRefs } from 'pinia'
 import { ionicStubs } from './ionic-stubs'
 
 // Mock browser APIs that don't exist in jsdom
@@ -44,8 +38,7 @@ class MockIntersectionObserver {
   rootMargin = ''
   thresholds = []
 }
-global.IntersectionObserver =
-  MockIntersectionObserver as unknown as typeof IntersectionObserver
+global.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver
 
 // Mock ResizeObserver
 class MockResizeObserver {
@@ -251,9 +244,7 @@ global.useAuthService = () => ({
       user: { id: 1, email: 'test@example.com' }
     })
   ),
-  getProfile: vi.fn(() =>
-    Promise.resolve({ id: 1, email: 'test@example.com' })
-  ),
+  getProfile: vi.fn(() => Promise.resolve({ id: 1, email: 'test@example.com' })),
   sendPasswordReset: vi.fn(() => Promise.resolve()),
   verifyEmail: vi.fn(() => Promise.resolve())
 })

--- a/tests/setup/test-setup.ts
+++ b/tests/setup/test-setup.ts
@@ -409,6 +409,10 @@ global.useUserRole = () => ({
   getUserRole: vi.fn(() => null)
 })
 
+vi.mock('vue-i18n', () => ({
+  useI18n: () => global.useI18n()
+}))
+
 // Mock useI18n composable
 global.useI18n = () => ({
   t: (key: string) => key,

--- a/tests/unit/api/LogRepository.test.ts
+++ b/tests/unit/api/LogRepository.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { LogRepository } from '~/composables/api/repositories/LogRepository'
-import type {
-  CreateLogRequest,
-  CreateLogResponse
-} from '~/shared/types/api/log'
+import type { CreateLogRequest, CreateLogResponse } from '~/shared/types/api/log'
 
 vi.mock('~/composables/useApiEndpoints', () => ({
   useApiEndpoints: vi.fn(() => ({
@@ -52,10 +49,9 @@ describe('LogRepository', () => {
         _id: 'log-mongo-id-789'
       }
 
-      vi.spyOn(
-        repository as unknown as { request: () => unknown },
-        'request'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { request: () => unknown }, 'request').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createProcessLog(logData, params)
 
@@ -77,10 +73,9 @@ describe('LogRepository', () => {
         _id: 'log-legacy-id'
       }
 
-      vi.spyOn(
-        repository as unknown as { request: () => unknown },
-        'request'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { request: () => unknown }, 'request').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createProcessLog(logData, params)
 
@@ -110,10 +105,9 @@ describe('LogRepository', () => {
         _id: 'log-null-id'
       }
 
-      vi.spyOn(
-        repository as unknown as { request: () => unknown },
-        'request'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { request: () => unknown }, 'request').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createProcessLog(logData, params)
 
@@ -142,10 +136,9 @@ describe('LogRepository', () => {
         _id: 'log-empty-id'
       }
 
-      vi.spyOn(
-        repository as unknown as { request: () => unknown },
-        'request'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { request: () => unknown }, 'request').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createProcessLog(logData, params)
 
@@ -169,10 +162,9 @@ describe('LogRepository', () => {
         _id: 'log-content-123'
       }
 
-      vi.spyOn(
-        repository as unknown as { request: () => unknown },
-        'request'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { request: () => unknown }, 'request').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createContentLog(logData)
 
@@ -196,10 +188,9 @@ describe('LogRepository', () => {
         _id: 'log-content-456'
       }
 
-      vi.spyOn(
-        repository as unknown as { request: () => unknown },
-        'request'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { request: () => unknown }, 'request').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createContentLog(logData, params)
 

--- a/tests/unit/api/repositories/CompanyRepository.test.ts
+++ b/tests/unit/api/repositories/CompanyRepository.test.ts
@@ -47,18 +47,14 @@ describe('CompanyRepository', () => {
         business_id: 'BIZ123'
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.updateCompany(companyId, updateData)
 
       expect(result).toEqual(mockResponse)
-      expect(repository.put).toHaveBeenCalledWith(
-        `/api/v1/companies/${companyId}`,
-        updateData
-      )
+      expect(repository.put).toHaveBeenCalledWith(`/api/v1/companies/${companyId}`, updateData)
     })
 
     it('should update only name field', async () => {
@@ -75,18 +71,14 @@ describe('CompanyRepository', () => {
         city: 'Old City'
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.updateCompany(companyId, updateData)
 
       expect(result.name).toBe('New Company Name')
-      expect(repository.put).toHaveBeenCalledWith(
-        `/api/v1/companies/${companyId}`,
-        updateData
-      )
+      expect(repository.put).toHaveBeenCalledWith(`/api/v1/companies/${companyId}`, updateData)
     })
 
     it('should update multiple fields', async () => {
@@ -106,10 +98,9 @@ describe('CompanyRepository', () => {
         ...updateData
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.updateCompany(companyId, updateData)
 
@@ -127,14 +118,11 @@ describe('CompanyRepository', () => {
         data: { message: 'Unauthorized' }
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockRejectedValue(error)
 
-      await expect(
-        repository.updateCompany('company-123', { name: 'Test' })
-      ).rejects.toMatchObject(error)
+      await expect(repository.updateCompany('company-123', { name: 'Test' })).rejects.toMatchObject(
+        error
+      )
     })
 
     it('should handle 403 forbidden error', async () => {
@@ -143,14 +131,11 @@ describe('CompanyRepository', () => {
         data: { message: 'Permission denied' }
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockRejectedValue(error)
 
-      await expect(
-        repository.updateCompany('company-123', { name: 'Test' })
-      ).rejects.toMatchObject(error)
+      await expect(repository.updateCompany('company-123', { name: 'Test' })).rejects.toMatchObject(
+        error
+      )
     })
 
     it('should handle 404 not found error', async () => {
@@ -159,14 +144,11 @@ describe('CompanyRepository', () => {
         data: { message: 'Company not found' }
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockRejectedValue(error)
 
-      await expect(
-        repository.updateCompany('company-123', { name: 'Test' })
-      ).rejects.toMatchObject(error)
+      await expect(repository.updateCompany('company-123', { name: 'Test' })).rejects.toMatchObject(
+        error
+      )
     })
 
     it('should handle 500 server error', async () => {
@@ -175,27 +157,21 @@ describe('CompanyRepository', () => {
         data: { message: 'Internal server error' }
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockRejectedValue(error)
 
-      await expect(
-        repository.updateCompany('company-123', { name: 'Test' })
-      ).rejects.toMatchObject(error)
+      await expect(repository.updateCompany('company-123', { name: 'Test' })).rejects.toMatchObject(
+        error
+      )
     })
 
     it('should handle network errors', async () => {
       const error = new Error('Network connection failed')
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockRejectedValue(error)
 
-      await expect(
-        repository.updateCompany('company-123', { name: 'Test' })
-      ).rejects.toThrow('Network connection failed')
+      await expect(repository.updateCompany('company-123', { name: 'Test' })).rejects.toThrow(
+        'Network connection failed'
+      )
     })
 
     it('should handle empty update data', async () => {
@@ -208,18 +184,14 @@ describe('CompanyRepository', () => {
         name: 'Unchanged Company'
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.updateCompany(companyId, updateData)
 
       expect(result).toEqual(mockResponse)
-      expect(repository.put).toHaveBeenCalledWith(
-        `/api/v1/companies/${companyId}`,
-        {}
-      )
+      expect(repository.put).toHaveBeenCalledWith(`/api/v1/companies/${companyId}`, {})
     })
 
     it('should map MongoDB _id to id in response', async () => {
@@ -233,10 +205,9 @@ describe('CompanyRepository', () => {
         name: 'MongoDB Company'
       }
 
-      vi.spyOn(
-        repository as unknown as { put: () => unknown },
-        'put'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { put: () => unknown }, 'put').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.updateCompany(companyId, updateData)
 

--- a/tests/unit/components/VideoCard.test.ts
+++ b/tests/unit/components/VideoCard.test.ts
@@ -231,9 +231,7 @@ describe('VideoCard', () => {
       expect(iframe.attributes('sandbox')).toBe(
         'allow-scripts allow-same-origin allow-presentation'
       )
-      expect(iframe.attributes('allow')).toBe(
-        'autoplay; fullscreen; picture-in-picture'
-      )
+      expect(iframe.attributes('allow')).toBe('autoplay; fullscreen; picture-in-picture')
     })
 
     it('should display video title', () => {
@@ -411,9 +409,7 @@ describe('VideoCard', () => {
       })
 
       const iframe = wrapper.find('iframe')
-      expect(iframe.attributes('aria-label')).toBe(
-        freeVideoWithQueryParams.title
-      )
+      expect(iframe.attributes('aria-label')).toBe(freeVideoWithQueryParams.title)
     })
 
     it('should have allowfullscreen attribute', () => {

--- a/tests/unit/composables/useCompanyEdit.test.ts
+++ b/tests/unit/composables/useCompanyEdit.test.ts
@@ -34,8 +34,7 @@ vi.mock('vee-validate', () => ({
           Object.assign(mockFormValues, opts.values)
           Object.keys(opts.values).forEach(key => {
             if (mockFieldRefs[key]) {
-              ;(mockFieldRefs[key] as { value: unknown }).value =
-                opts.values[key]
+              ;(mockFieldRefs[key] as { value: unknown }).value = opts.values[key]
             }
           })
         }
@@ -56,10 +55,7 @@ vi.mock('vee-validate', () => ({
       mockFieldRefs[name] = fieldRef
 
       // Watch for changes to the ref and update form values
-      const originalSetter = Object.getOwnPropertyDescriptor(
-        fieldRef,
-        'value'
-      )?.set
+      const originalSetter = Object.getOwnPropertyDescriptor(fieldRef, 'value')?.set
       Object.defineProperty(fieldRef, 'value', {
         get() {
           return mockFormValues[name] ?? ''

--- a/tests/unit/composables/useCompanyInitialization.test.ts
+++ b/tests/unit/composables/useCompanyInitialization.test.ts
@@ -67,9 +67,7 @@ describe('useCompanyInitialization', () => {
 
     it('should handle edge cases gracefully', () => {
       expect(companyInit.extractNameFromEmail('')).toBe("User's Farm")
-      expect(companyInit.extractNameFromEmail('invalid')).toBe(
-        "Invalid's Farm"
-      )
+      expect(companyInit.extractNameFromEmail('invalid')).toBe("Invalid's Farm")
       expect(companyInit.extractNameFromEmail('@')).toBe("User's Farm")
     })
   })
@@ -82,26 +80,20 @@ describe('useCompanyInitialization', () => {
         created_spaces: ['space1', 'space2', 'space3']
       })
 
-      const result = await companyInit.createCompanyWithSpaces(
-        'test-token',
-        'test.user@email.com'
-      )
+      const result = await companyInit.createCompanyWithSpaces('test-token', 'test.user@email.com')
 
-      expect(mockApi).toHaveBeenCalledWith(
-        '/companies?create_all_spaces=true',
-        {
-          method: 'POST',
-          body: {
-            name: "Test User's Farm",
-            city: 'Helsinki',
-            country: 'FI',
-            timezone: 'Europe/Helsinki'
-          },
-          headers: {
-            Authorization: 'Bearer test-token'
-          }
+      expect(mockApi).toHaveBeenCalledWith('/companies?create_all_spaces=true', {
+        method: 'POST',
+        body: {
+          name: "Test User's Farm",
+          city: 'Helsinki',
+          country: 'FI',
+          timezone: 'Europe/Helsinki'
+        },
+        headers: {
+          Authorization: 'Bearer test-token'
         }
-      )
+      })
 
       expect(result).toEqual({
         status: 'success',

--- a/tests/unit/composables/useCurrencyExchange.test.ts
+++ b/tests/unit/composables/useCurrencyExchange.test.ts
@@ -91,10 +91,7 @@ describe('useCurrencyExchange', () => {
           timestamp: Date.now() - 1000
         }
       }
-      localStorageMock.setItem(
-        'currency_exchange_rates',
-        JSON.stringify(cache)
-      )
+      localStorageMock.setItem('currency_exchange_rates', JSON.stringify(cache))
       const { getUSDRate } = useCurrencyExchange()
       const rate = await getUSDRate('EUR')
       expect(rate).toBe(1.2)
@@ -107,10 +104,7 @@ describe('useCurrencyExchange', () => {
           timestamp: Date.now() - 25 * 60 * 60 * 1000
         }
       }
-      localStorageMock.setItem(
-        'currency_exchange_rates',
-        JSON.stringify(cache)
-      )
+      localStorageMock.setItem('currency_exchange_rates', JSON.stringify(cache))
       const mockResponse = {
         ok: true,
         json: vi.fn().mockResolvedValue({

--- a/tests/unit/composables/useHelp.test.ts
+++ b/tests/unit/composables/useHelp.test.ts
@@ -88,9 +88,7 @@ describe('useHelp', () => {
     console.debug = vi.fn()
 
     // Reset modal mock
-    mockModal.onDidDismiss.mockReturnValue(
-      Promise.resolve({ data: undefined, role: undefined })
-    )
+    mockModal.onDidDismiss.mockReturnValue(Promise.resolve({ data: undefined, role: undefined }))
 
     // Mock window properties
     Object.defineProperty(window, 'pageYOffset', {
@@ -173,8 +171,7 @@ describe('useHelp', () => {
       await showHelp(HelpTopic.ACCOUNT_SECURITY)
 
       expect(mockModal.querySelector).toHaveBeenCalledWith(
-        '[autofocus], button, [href], input, select, textarea, ' +
-          '[tabindex]:not([tabindex="-1"])'
+        '[autofocus], button, [href], input, select, textarea, ' + '[tabindex]:not([tabindex="-1"])'
       )
 
       // Cleanup
@@ -208,10 +205,7 @@ describe('useHelp', () => {
       })
 
       expect(mockModal.present).toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledWith(
-        '[useHelp] Opening help modal',
-        expect.any(Object)
-      )
+      expect(console.log).toHaveBeenCalledWith('[useHelp] Opening help modal', expect.any(Object))
     })
 
     it('should handle invalid topic', async () => {
@@ -219,10 +213,7 @@ describe('useHelp', () => {
 
       await showHelp('invalid.topic' as HelpTopic)
 
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Invalid help topic:',
-        'invalid.topic'
-      )
+      expect(console.warn).toHaveBeenCalledWith('[useHelp] Invalid help topic:', 'invalid.topic')
 
       // Should still create modal but with null topic
       expect(mockModalController.create).toHaveBeenCalledWith(
@@ -287,10 +278,7 @@ describe('useHelp', () => {
 
       await showHelp(HelpTopic.GETTING_STARTED)
 
-      expect(console.debug).toHaveBeenCalledWith(
-        '[useHelp] Saved scroll position:',
-        500
-      )
+      expect(console.debug).toHaveBeenCalledWith('[useHelp] Saved scroll position:', 500)
     })
 
     it('should save focus element', async () => {
@@ -304,18 +292,13 @@ describe('useHelp', () => {
 
       await showHelp(HelpTopic.GETTING_STARTED)
 
-      expect(console.debug).toHaveBeenCalledWith(
-        '[useHelp] Saved focus element:',
-        'INPUT'
-      )
+      expect(console.debug).toHaveBeenCalledWith('[useHelp] Saved focus element:', 'INPUT')
     })
 
     it('should handle modal creation error', async () => {
       const { showHelp } = useHelp()
 
-      mockModalController.create.mockRejectedValueOnce(
-        new Error('Creation failed')
-      )
+      mockModalController.create.mockRejectedValueOnce(new Error('Creation failed'))
 
       await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow(
         'Unable to create help modal. Please try again.'
@@ -332,9 +315,7 @@ describe('useHelp', () => {
 
       mockModal.present.mockRejectedValueOnce(new Error('Present failed'))
 
-      await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow(
-        'Present failed'
-      )
+      await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow('Present failed')
 
       expect(console.error).toHaveBeenCalledWith(
         '[useHelp] Error showing help modal:',
@@ -440,10 +421,7 @@ describe('useHelp', () => {
     it('should handle modal dismissal', async () => {
       const { showHelp } = useHelp()
 
-      let dismissCallback: (value: {
-        data: undefined
-        role?: string
-      }) => void = () => {}
+      let dismissCallback: (value: { data: undefined; role?: string }) => void = () => {}
       mockModal.onDidDismiss.mockImplementation(() => {
         return {
           then: (callback: (value: { data: undefined }) => void) => {
@@ -460,10 +438,7 @@ describe('useHelp', () => {
       // Simulate modal dismiss
       dismissCallback({ data: undefined, role: 'backdrop' })
 
-      expect(console.log).toHaveBeenCalledWith(
-        '[useHelp] Modal dismissed',
-        expect.any(Object)
-      )
+      expect(console.log).toHaveBeenCalledWith('[useHelp] Modal dismissed', expect.any(Object))
     })
 
     it('should restore scroll position on dismiss', async () => {
@@ -472,10 +447,7 @@ describe('useHelp', () => {
       window.pageYOffset = 500
       const scrollToSpy = vi.spyOn(window, 'scrollTo')
 
-      let dismissCallback: (value: {
-        data: undefined
-        role?: string
-      }) => void = () => {}
+      let dismissCallback: (value: { data: undefined; role?: string }) => void = () => {}
       mockModal.onDidDismiss.mockImplementation(() => {
         return {
           then: (callback: (value: { data: undefined }) => void) => {
@@ -493,10 +465,7 @@ describe('useHelp', () => {
       dismissCallback({ data: undefined, role: 'backdrop' })
 
       expect(scrollToSpy).toHaveBeenCalledWith(0, 500)
-      expect(console.debug).toHaveBeenCalledWith(
-        '[useHelp] Restored scroll position:',
-        500
-      )
+      expect(console.debug).toHaveBeenCalledWith('[useHelp] Restored scroll position:', 500)
     })
 
     it('should restore focus on dismiss', async () => {
@@ -508,10 +477,7 @@ describe('useHelp', () => {
         configurable: true
       })
 
-      let dismissCallback: (value: {
-        data: undefined
-        role?: string
-      }) => void = () => {}
+      let dismissCallback: (value: { data: undefined; role?: string }) => void = () => {}
       mockModal.onDidDismiss.mockImplementation(() => {
         return {
           then: (callback: (value: { data: undefined }) => void) => {
@@ -529,10 +495,7 @@ describe('useHelp', () => {
       dismissCallback({ data: undefined, role: 'backdrop' })
 
       expect(mockElement.focus).toHaveBeenCalled()
-      expect(console.debug).toHaveBeenCalledWith(
-        '[useHelp] Restored focus to:',
-        'INPUT'
-      )
+      expect(console.debug).toHaveBeenCalledWith('[useHelp] Restored focus to:', 'INPUT')
     })
 
     it('should handle dismiss callback error', async () => {
@@ -584,9 +547,7 @@ describe('useHelp', () => {
 
       await nextTick()
 
-      expect(console.debug).toHaveBeenCalledWith(
-        '[useHelp] Escape key pressed, closing modal'
-      )
+      expect(console.debug).toHaveBeenCalledWith('[useHelp] Escape key pressed, closing modal')
 
       // Cleanup
       if (dismissResolve) {
@@ -605,9 +566,7 @@ describe('useHelp', () => {
 
       await nextTick()
 
-      expect(console.debug).not.toHaveBeenCalledWith(
-        '[useHelp] Escape key pressed, closing modal'
-      )
+      expect(console.debug).not.toHaveBeenCalledWith('[useHelp] Escape key pressed, closing modal')
     })
 
     it('should not close modal if no modal is open', async () => {
@@ -676,10 +635,7 @@ describe('useHelp', () => {
         throw new Error('Cannot scroll')
       })
 
-      let dismissCallback: (value: {
-        data: undefined
-        role?: string
-      }) => void = () => {}
+      let dismissCallback: (value: { data: undefined; role?: string }) => void = () => {}
       mockModal.onDidDismiss.mockImplementation(() => {
         return {
           then: (callback: (value: { data: undefined }) => void) => {
@@ -714,10 +670,7 @@ describe('useHelp', () => {
         configurable: true
       })
 
-      let dismissCallback: (value: {
-        data: undefined
-        role?: string
-      }) => void = () => {}
+      let dismissCallback: (value: { data: undefined; role?: string }) => void = () => {}
       mockModal.onDidDismiss.mockImplementation(() => {
         return {
           then: (callback: (value: { data: undefined }) => void) => {

--- a/tests/unit/composables/useHelpTopic.test.ts
+++ b/tests/unit/composables/useHelpTopic.test.ts
@@ -55,21 +55,17 @@ describe('useHelpTopic logic', () => {
     })
 
     it('maps account routes to PROFILE_SETTINGS', () => {
-      expect(getHelpTopicForRoute({ path: '/account' })).toBe(
-        HelpTopic.PROFILE_SETTINGS
-      )
+      expect(getHelpTopicForRoute({ path: '/account' })).toBe(HelpTopic.PROFILE_SETTINGS)
       expect(getHelpTopicForRoute({ path: '/account?tab=settings' })).toBe(
         HelpTopic.PROFILE_SETTINGS
       )
     })
 
     it('maps verification routes to ACCOUNT_SECURITY', () => {
-      expect(getHelpTopicForRoute({ path: '/verify-token' })).toBe(
+      expect(getHelpTopicForRoute({ path: '/verify-token' })).toBe(HelpTopic.ACCOUNT_SECURITY)
+      expect(getHelpTopicForRoute({ path: '/auth/verify-email?token=abc' })).toBe(
         HelpTopic.ACCOUNT_SECURITY
       )
-      expect(
-        getHelpTopicForRoute({ path: '/auth/verify-email?token=abc' })
-      ).toBe(HelpTopic.ACCOUNT_SECURITY)
       expect(
         getHelpTopicForRoute({
           path: '/auth/verify-email',
@@ -81,24 +77,16 @@ describe('useHelpTopic logic', () => {
 
   describe('Locale-prefixed routes', () => {
     it('handles locale prefixes for root and main routes', () => {
-      expect(getHelpTopicForRoute({ path: '/es/' })).toBe(
-        HelpTopic.GETTING_STARTED
-      )
-      expect(getHelpTopicForRoute({ path: '/fr/main' })).toBe(
-        HelpTopic.GETTING_STARTED
-      )
+      expect(getHelpTopicForRoute({ path: '/es/' })).toBe(HelpTopic.GETTING_STARTED)
+      expect(getHelpTopicForRoute({ path: '/fr/main' })).toBe(HelpTopic.GETTING_STARTED)
     })
 
     it('handles locale prefixes for account routes', () => {
-      expect(getHelpTopicForRoute({ path: '/de/account' })).toBe(
-        HelpTopic.PROFILE_SETTINGS
-      )
+      expect(getHelpTopicForRoute({ path: '/de/account' })).toBe(HelpTopic.PROFILE_SETTINGS)
     })
 
     it('handles locale prefixes for verify routes', () => {
-      expect(getHelpTopicForRoute({ path: '/pt/verify-token' })).toBe(
-        HelpTopic.ACCOUNT_SECURITY
-      )
+      expect(getHelpTopicForRoute({ path: '/pt/verify-token' })).toBe(HelpTopic.ACCOUNT_SECURITY)
     })
   })
 

--- a/tests/unit/composables/useTextFormatting.test.ts
+++ b/tests/unit/composables/useTextFormatting.test.ts
@@ -87,9 +87,7 @@ describe('useTextFormatting', () => {
       })
 
       it('should handle combined formatting', () => {
-        const input =
-          '# Title\n\n**Bold** and *italic* with ' +
-          '[link](https://example.com)'
+        const input = '# Title\n\n**Bold** and *italic* with ' + '[link](https://example.com)'
         const result = textFormatting.formatMarkdown(input)
         expect(result).toContain('<h1>Title</h1>')
         expect(result).toContain('<strong>Bold</strong>')
@@ -135,8 +133,7 @@ describe('useTextFormatting', () => {
       })
 
       it('should remove style attributes with javascript', () => {
-        const input =
-          '<p style="background: url(javascript:alert(1))">Text</p>'
+        const input = '<p style="background: url(javascript:alert(1))">Text</p>'
         const result = textFormatting.formatMarkdown(input)
         expect(result).not.toContain('style')
         expect(result).not.toContain('javascript')
@@ -165,15 +162,11 @@ describe('useTextFormatting', () => {
       })
 
       it('should handle null input', () => {
-        expect(textFormatting.formatMarkdown(null as unknown as string)).toBe(
-          ''
-        )
+        expect(textFormatting.formatMarkdown(null as unknown as string)).toBe('')
       })
 
       it('should handle undefined input', () => {
-        expect(
-          textFormatting.formatMarkdown(undefined as unknown as string)
-        ).toBe('')
+        expect(textFormatting.formatMarkdown(undefined as unknown as string)).toBe('')
       })
 
       it('should truncate very long input', () => {
@@ -207,8 +200,7 @@ describe('useTextFormatting', () => {
       })
 
       it('should preserve allowed HTML tags', () => {
-        const input =
-          '# Title\n\n<p>Paragraph</p>\n<blockquote>Quote</blockquote>'
+        const input = '# Title\n\n<p>Paragraph</p>\n<blockquote>Quote</blockquote>'
         const result = textFormatting.formatMarkdown(input)
         expect(result).toContain('<h1>Title</h1>')
         expect(result).toContain('<p>Paragraph</p>')
@@ -247,8 +239,7 @@ describe('useTextFormatting', () => {
   describe('extractUrls', () => {
     describe('URL Extraction from Markdown', () => {
       it('should extract markdown links', () => {
-        const input =
-          '[Google](https://google.com) and [GitHub](https://github.com)'
+        const input = '[Google](https://google.com) and [GitHub](https://github.com)'
         const result = textFormatting.extractUrls(input)
 
         expect(result).toHaveLength(2)
@@ -367,15 +358,11 @@ describe('useTextFormatting', () => {
       })
 
       it('should handle null input', () => {
-        expect(textFormatting.extractUrls(null as unknown as string)).toEqual(
-          []
-        )
+        expect(textFormatting.extractUrls(null as unknown as string)).toEqual([])
       })
 
       it('should handle undefined input', () => {
-        expect(
-          textFormatting.extractUrls(undefined as unknown as string)
-        ).toEqual([])
+        expect(textFormatting.extractUrls(undefined as unknown as string)).toEqual([])
       })
 
       it('should handle text with no URLs', () => {
@@ -432,8 +419,7 @@ describe('useTextFormatting', () => {
       })
 
       it('should handle URLs at start and end of text', () => {
-        const input =
-          'https://start.com in middle https://middle.com ' + 'https://end.com'
+        const input = 'https://start.com in middle https://middle.com ' + 'https://end.com'
         const result = textFormatting.extractUrls(input)
 
         expect(result).toHaveLength(3)
@@ -553,9 +539,7 @@ https://another-safe.com
       expect(emptyFormatted).toBe('')
       expect(emptyUrls).toEqual([])
 
-      const nullFormatted = textFormatting.formatMarkdown(
-        null as unknown as string
-      )
+      const nullFormatted = textFormatting.formatMarkdown(null as unknown as string)
       const nullUrls = textFormatting.extractUrls(null as unknown as string)
 
       expect(nullFormatted).toBe('')

--- a/tests/unit/composables/useUserRole.test.ts
+++ b/tests/unit/composables/useUserRole.test.ts
@@ -1,12 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  vi,
-  beforeAll,
-  afterAll
-} from 'vitest'
+import { describe, it, expect, beforeEach, vi, beforeAll, afterAll } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore as realUseAuthStore } from '~/stores/auth'
 import { useUserRole } from '~/composables/useUserRole'
@@ -27,16 +19,12 @@ beforeAll(() => {
       return value ? value : null
     },
     set: (key: string, value: unknown) => {
-      mockStorage[key] =
-        typeof value === 'string' ? value : JSON.stringify(value)
+      mockStorage[key] = typeof value === 'string' ? value : JSON.stringify(value)
     },
     remove: (key: string) => {
       const keys = Object.keys(mockStorage)
       keys.forEach(k => {
-        if (
-          k === key &&
-          Object.prototype.hasOwnProperty.call(mockStorage, k)
-        ) {
+        if (k === key && Object.prototype.hasOwnProperty.call(mockStorage, k)) {
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
           delete mockStorage[k]
         }
@@ -84,12 +72,8 @@ describe('useUserRole', () => {
       { _id: 'admin1', id: 'admin1', email: 'admin1@test.com' },
       { _id: 'admin2', id: 'admin2', email: 'admin2@test.com' }
     ]
-    mockManagers = [
-      { _id: 'manager1', id: 'manager1', email: 'mgr1@test.com' }
-    ]
-    mockOperators = [
-      { _id: 'operator1', id: 'operator1', email: 'op1@test.com' }
-    ]
+    mockManagers = [{ _id: 'manager1', id: 'manager1', email: 'mgr1@test.com' }]
+    mockOperators = [{ _id: 'operator1', id: 'operator1', email: 'op1@test.com' }]
   })
 
   describe('isCompanyAdmin', () => {
@@ -386,15 +370,11 @@ describe('useUserRole', () => {
       authStore.setUser({ _id: 'user1', id: 'user1', email: 'u@test.com' })
       authStore.setActiveCompany({ _id: 'comp1', id: 'comp1' })
 
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {})
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[useUserRole] localStorage not available'
-      )
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[useUserRole] localStorage not available')
 
       consoleWarnSpy.mockRestore()
       global.window = originalWindow
@@ -406,9 +386,7 @@ describe('useUserRole', () => {
 
       mockStorage['auth_active_company_roles'] = '{ invalid json }'
 
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
@@ -438,15 +416,11 @@ describe('useUserRole', () => {
         invalid: 'structure'
       })
 
-      const consoleWarnSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => {})
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        '[useUserRole] Invalid role data structure'
-      )
+      expect(consoleWarnSpy).toHaveBeenCalledWith('[useUserRole] Invalid role data structure')
 
       consoleWarnSpy.mockRestore()
     })
@@ -469,15 +443,11 @@ describe('useUserRole', () => {
         clear: vi.fn()
       })
 
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[useUserRole] localStorage quota exceeded'
-      )
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[useUserRole] localStorage quota exceeded')
 
       consoleErrorSpy.mockRestore()
       // Restore original
@@ -505,15 +475,11 @@ describe('useUserRole', () => {
         clear: vi.fn()
       })
 
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[useUserRole] localStorage access denied'
-      )
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[useUserRole] localStorage access denied')
 
       consoleErrorSpy.mockRestore()
     })
@@ -524,9 +490,7 @@ describe('useUserRole', () => {
 
       mockStorage['auth_active_company_roles'] = 'invalid json'
 
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
       const { hasAnyRole } = useUserRole()
 

--- a/tests/unit/composables/validation/useFormValidation.test.ts
+++ b/tests/unit/composables/validation/useFormValidation.test.ts
@@ -12,20 +12,14 @@ import {
 describe('useFormValidation', () => {
   describe('validationSchemas', () => {
     it('should validate email correctly', () => {
-      expect(
-        validationSchemas.email.safeParse('test@example.com').success
-      ).toBe(true)
+      expect(validationSchemas.email.safeParse('test@example.com').success).toBe(true)
       expect(validationSchemas.email.safeParse('invalid').success).toBe(false)
       expect(validationSchemas.email.safeParse('').success).toBe(false)
     })
 
     it('should validate password with min 8 chars', () => {
-      expect(validationSchemas.password.safeParse('12345678').success).toBe(
-        true
-      )
-      expect(validationSchemas.password.safeParse('1234567').success).toBe(
-        false
-      )
+      expect(validationSchemas.password.safeParse('12345678').success).toBe(true)
+      expect(validationSchemas.password.safeParse('1234567').success).toBe(false)
       const result = validationSchemas.password.safeParse('short')
       if (!result.success) {
         expect(result.error.issues[0].message).toContain('8 characters')
@@ -42,25 +36,15 @@ describe('useFormValidation', () => {
     })
 
     it('should validate phone number', () => {
-      expect(validationSchemas.phone.safeParse('+1234567890').success).toBe(
-        true
-      )
-      expect(validationSchemas.phone.safeParse('123-456-7890').success).toBe(
-        true
-      )
-      expect(validationSchemas.phone.safeParse('(123) 456-7890').success).toBe(
-        true
-      )
+      expect(validationSchemas.phone.safeParse('+1234567890').success).toBe(true)
+      expect(validationSchemas.phone.safeParse('123-456-7890').success).toBe(true)
+      expect(validationSchemas.phone.safeParse('(123) 456-7890').success).toBe(true)
       expect(validationSchemas.phone.safeParse('abc').success).toBe(false)
     })
 
     it('should validate URL', () => {
-      expect(
-        validationSchemas.url.safeParse('https://example.com').success
-      ).toBe(true)
-      expect(
-        validationSchemas.url.safeParse('http://example.com').success
-      ).toBe(true)
+      expect(validationSchemas.url.safeParse('https://example.com').success).toBe(true)
+      expect(validationSchemas.url.safeParse('http://example.com').success).toBe(true)
       expect(validationSchemas.url.safeParse('not-a-url').success).toBe(false)
     })
   })
@@ -129,9 +113,7 @@ describe('useFormValidation', () => {
 
       await form.validate()
       expect(form.errors.value.confirmPassword).toBeTruthy()
-      expect(form.errors.value.confirmPassword).toContain(
-        "Passwords don't match"
-      )
+      expect(form.errors.value.confirmPassword).toContain("Passwords don't match")
     })
 
     it('should require all mandatory fields', async () => {

--- a/tests/unit/stores/auth.test.ts
+++ b/tests/unit/stores/auth.test.ts
@@ -1,13 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeEach,
-  vi,
-  afterEach,
-  beforeAll,
-  afterAll
-} from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach, beforeAll, afterAll } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from '~/stores/auth'
 import type { ProfileResponse } from '~/composables/api/repositories/ProfileRepository'
@@ -32,16 +23,12 @@ beforeAll(() => {
       return value ? value : null
     },
     set: (key: string, value: unknown) => {
-      mockStorage[key] =
-        typeof value === 'string' ? value : JSON.stringify(value)
+      mockStorage[key] = typeof value === 'string' ? value : JSON.stringify(value)
     },
     remove: (key: string) => {
       const keys = Object.keys(mockStorage)
       keys.forEach(k => {
-        if (
-          k === key &&
-          Object.prototype.hasOwnProperty.call(mockStorage, k)
-        ) {
+        if (k === key && Object.prototype.hasOwnProperty.call(mockStorage, k)) {
           // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
           delete mockStorage[k]
         }
@@ -104,12 +91,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           { _id: 'comp3', name: 'Other Co 2' }
         ]
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
-      mockGetCurrentProfile = vi
-        .fn()
-        .mockResolvedValue(profileWithActiveCompany)
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithActiveCompany)
       mockSwitchCompany = vi.fn()
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
@@ -140,9 +123,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         active_company: null,
         other_companies: []
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithNoCompanies)
       mockSwitchCompany = vi.fn()
       ;(
@@ -188,12 +169,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           operators: []
         }
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
-      mockGetCurrentProfile = vi
-        .fn()
-        .mockResolvedValue(profileWithoutActiveCompany)
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
@@ -209,13 +186,11 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         id: 'comp1',
         name: 'First Co'
       })
-      const otherComps = profileWithoutActiveCompany.other_companies.map(
-        c => ({
-          ...c,
-          id: c._id || c.id,
-          _id: c._id || c.id
-        })
-      )
+      const otherComps = profileWithoutActiveCompany.other_companies.map(c => ({
+        ...c,
+        id: c._id || c.id,
+        _id: c._id || c.id
+      }))
       expect(store.otherCompanies).toEqual(otherComps)
       expect(store.user).toEqual({
         ...updatedProfile.user,
@@ -249,9 +224,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           operators: []
         }
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithIdField)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
       ;(
@@ -281,9 +254,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           { _id: 'comp2', name: 'Valid Company' }
         ]
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithInvalidId)
       mockSwitchCompany = vi.fn()
       ;(
@@ -292,9 +263,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       await store.fetchProfile()
       expect(mockSwitchCompany).not.toHaveBeenCalled()
       const errorMsg = '[AUTH] First company has no valid ID'
@@ -336,12 +305,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           operators: []
         }
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
-      mockGetCurrentProfile = vi
-        .fn()
-        .mockResolvedValue(profileWithoutActiveCompany)
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi
         .fn()
         .mockRejectedValueOnce(new Error('Network error'))
@@ -354,9 +319,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleLogSpy = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const fetchPromise = store.fetchProfile()
       await vi.runOnlyPendingTimersAsync()
       await vi.advanceTimersByTimeAsync(1000)
@@ -365,9 +328,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       await fetchPromise
       expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
       expect(mockSwitchCompany).toHaveBeenCalledWith('comp1')
-      expect(consoleLogSpy).toHaveBeenCalledWith(
-        '[AUTH] Successfully auto-selected company'
-      )
+      expect(consoleLogSpy).toHaveBeenCalledWith('[AUTH] Successfully auto-selected company')
       expect(store.activeCompany).toEqual({
         _id: 'comp1',
         id: 'comp1',
@@ -390,27 +351,17 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           { _id: 'comp2', name: 'Second Co' }
         ]
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
-      mockGetCurrentProfile = vi
-        .fn()
-        .mockResolvedValue(profileWithoutActiveCompany)
-      mockSwitchCompany = vi
-        .fn()
-        .mockRejectedValue(new Error('Persistent API failure'))
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
+      mockSwitchCompany = vi.fn().mockRejectedValue(new Error('Persistent API failure'))
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
       ).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleLogSpy = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const fetchPromise = store.fetchProfile()
       await vi.runOnlyPendingTimersAsync()
       await vi.advanceTimersByTimeAsync(1000)
@@ -456,12 +407,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         active_company: null,
         other_companies: [{ _id: 'comp1', name: 'Test Co' }]
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
-      mockGetCurrentProfile = vi
-        .fn()
-        .mockResolvedValue(profileWithoutActiveCompany)
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockRejectedValue(new Error('Test error'))
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
@@ -469,12 +416,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleLogSpy = vi
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const fetchPromise = store.fetchProfile()
       await vi.runOnlyPendingTimersAsync()
       await vi.advanceTimersByTimeAsync(1000)
@@ -507,9 +450,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         },
         other_companies: []
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
@@ -546,12 +487,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           operators: []
         }
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
-      mockGetCurrentProfile = vi
-        .fn()
-        .mockResolvedValue(profileWithoutActiveCompany)
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
@@ -564,12 +501,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       expect(mockStorage['auth_active_company']).toBeDefined()
       expect(mockStorage['auth_other_companies']).toBeDefined()
       const storedUser = JSON.parse(mockStorage['auth_user'])
-      const storedActiveCompany = JSON.parse(
-        mockStorage['auth_active_company']
-      )
-      const storedOtherCompanies = JSON.parse(
-        mockStorage['auth_other_companies']
-      )
+      const storedActiveCompany = JSON.parse(mockStorage['auth_active_company'])
+      const storedOtherCompanies = JSON.parse(mockStorage['auth_other_companies'])
       expect(storedUser).toEqual({
         ...updatedProfile.user,
         id: updatedProfile.user._id
@@ -579,13 +512,11 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         id: 'comp1',
         name: 'Selected Co'
       })
-      const otherComps = profileWithoutActiveCompany.other_companies.map(
-        c => ({
-          ...c,
-          id: c._id || c.id,
-          _id: c._id || c.id
-        })
-      )
+      const otherComps = profileWithoutActiveCompany.other_companies.map(c => ({
+        ...c,
+        id: c._id || c.id,
+        _id: c._id || c.id
+      }))
       expect(storedOtherCompanies).toEqual(otherComps)
     })
     it('should return correct data structure from fetchProfile', async () => {
@@ -611,9 +542,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           operators: []
         }
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
       ;(
@@ -646,9 +575,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
   })
   describe('Error handling', () => {
     it('should throw error when fetchProfile fails completely', async () => {
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockRejectedValue(new Error('API Error'))
       ;(
         ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
@@ -656,9 +583,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: vi.fn()
       }))
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       await expect(store.fetchProfile()).rejects.toThrow('API Error')
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         '[AUTH] Failed to fetch profile:',
@@ -676,9 +601,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         active_company: null,
         other_companies: null as unknown as []
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       mockSwitchCompany = vi.fn()
       ;(
@@ -715,9 +638,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
           operators: []
         }
       }
-      const { ProfileRepository } = await import(
-        '~/composables/api/repositories/ProfileRepository'
-      )
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
       ;(

--- a/tests/unit/utils/countries.test.ts
+++ b/tests/unit/utils/countries.test.ts
@@ -62,18 +62,7 @@ should have flag`
 
     it('should include common countries', () => {
       const codes = COUNTRIES_DATA.map(c => c.code)
-      const commonCountries = [
-        'US',
-        'GB',
-        'CA',
-        'DE',
-        'FR',
-        'ES',
-        'IT',
-        'JP',
-        'CN',
-        'BR'
-      ]
+      const commonCountries = ['US', 'GB', 'CA', 'DE', 'FR', 'ES', 'IT', 'JP', 'CN', 'BR']
       commonCountries.forEach(code => {
         expect(codes).toContain(code)
       })

--- a/tests/unit/utils/regex-validation.test.ts
+++ b/tests/unit/utils/regex-validation.test.ts
@@ -42,18 +42,14 @@ describe('Regex Validation', () => {
 
     it('validates complex but safe patterns', () => {
       // Email-like pattern
-      expect(
-        isValidRegex('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$')
-      ).toBe(true)
+      expect(isValidRegex('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$')).toBe(true)
 
       // URL-like pattern
       expect(isValidRegex('https?://[\\w.-]+(/[\\w.-]*)*')).toBe(true)
 
       // Phone number pattern
       expect(
-        isValidRegex(
-          '\\+?\\d{1,3}[-.\\s]?\\(?\\d{1,4}\\)?[-.\\s]?\\d{1,4}[-.\\s]?\\d{1,9}'
-        )
+        isValidRegex('\\+?\\d{1,3}[-.\\s]?\\(?\\d{1,4}\\)?[-.\\s]?\\d{1,4}[-.\\s]?\\d{1,9}')
       ).toBe(true)
     })
 

--- a/tests/unit/utils/validation/companySchemas.test.ts
+++ b/tests/unit/utils/validation/companySchemas.test.ts
@@ -112,12 +112,7 @@ describe('companySchemas', () => {
     })
 
     it('should validate IANA timezone strings', () => {
-      const validTimezones = [
-        'Europe/Helsinki',
-        'America/New_York',
-        'Asia/Tokyo',
-        'UTC'
-      ]
+      const validTimezones = ['Europe/Helsinki', 'America/New_York', 'Asia/Tokyo', 'UTC']
       validTimezones.forEach(timezone => {
         const company = { timezone }
         const result = companyEditSchema.safeParse(company)

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -29,13 +29,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',
-      exclude: [
-        'node_modules/**',
-        'tests/**',
-        '**/*.config.*',
-        '.nuxt/**',
-        'dist/**'
-      ]
+      exclude: ['node_modules/**', 'tests/**', '**/*.config.*', '.nuxt/**', 'dist/**']
     }
   },
   resolve: {


### PR DESCRIPTION
## Summary

- adds explicit `useI18n` imports from `vue-i18n` across the affected app files to fix the broken auto-import typing path behind issue #19
- updates `translatedConstants.ts` and test setup so the explicit i18n import pattern works consistently in unit tests
- excludes `.claude/` from project Prettier and ESLint coverage to match the golden reference in `~/dev/bsf_market/main`
- runs a repo-wide Prettier pass on the remaining project files so the `format` CI job can pass again

## Why

PR #39 was functionally ready for #19, but the branch still failed the shared CI gates because this repo was linting and formatting external `.claude/` content plus carrying unresolved repo-wide formatting drift. That made merges noisy even when the feature change itself was correct.

This branch now fixes both layers together:

- issue #19: explicit `vue-i18n` imports
- issue #40: repo-wide format/lint unblock so CI can go green on normal app changes

Closes #19
Closes #40

## Impact

- restores a mergeable CI path for this branch and other normal PRs
- keeps `.claude/` treated as external content rather than app source
- preserves the existing CI lint command for now; tightening the warning ceiling remains follow-up work in #22

## Verification

- [x] `npm run format:check`
- [x] `npm run lint -- --max-warnings 153`
- [x] `npm run typecheck`
- [x] `npx vitest run --no-coverage`

## Notes For Review

- the diff includes a broad formatting-only sweep because `prettier --check .` was failing repo-wide, not just in the files touched by #19
- functional code changes are still the explicit `vue-i18n` import fixes plus the `.claude/` ignore configuration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Explicitly wired i18n across the app so UI strings (headers, menus, footers, form placeholders, error/toast messages, Vimeo invalid-URL text, video credits label) reliably use localized translations; various templates were also cleaned up without behavioral changes.

* **Tests**
  * Test setup updated to mock the i18n module so translations behave correctly in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->