### PR TITLE
ci: gate vue-tsc typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,16 @@ jobs:
       - run: npm ci
       - run: npx vitest run --no-coverage
         timeout-minutes: 10
+
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+        timeout-minutes: 5

--- a/FLOW.md
+++ b/FLOW.md
@@ -422,7 +422,7 @@ When sub-agents need guidance:
 
 - **Platform**: GitHub Actions
 - **Workflow**: `.github/workflows/ci.yml`
-- **Required Checks**: lint, format, typecheck, vitest unit tests
+- **Required Checks**: lint, format, typecheck, test (Vitest unit tests)
 - **Enforcement**: Pre-commit hooks via Husky; all checks must
   pass before merge
 - **Deploy**: Netlify (`netlify.toml`); build command

--- a/FLOW.md
+++ b/FLOW.md
@@ -245,9 +245,10 @@ Agents do NOT duplicate this locally.
 - **CI commands**:
   - Lint: `npm run lint -- --max-warnings 153`
   - Format: `npm run format:check`
+  - Typecheck: `npm run typecheck`
   - Tests: `npx vitest run --no-coverage`
 - **CI workflow file**: `.github/workflows/ci.yml`
-- **Required CI checks**: `lint`, `format`, `test`
+- **Required CI checks**: `lint`, `format`, `typecheck`, `test`
 - **Note**: Playwright e2e tests do NOT run in CI; they are
   manual/local only.
 
@@ -421,7 +422,7 @@ When sub-agents need guidance:
 
 - **Platform**: GitHub Actions
 - **Workflow**: `.github/workflows/ci.yml`
-- **Required Checks**: lint, format, vitest unit tests
+- **Required Checks**: lint, format, typecheck, vitest unit tests
 - **Enforcement**: Pre-commit hooks via Husky; all checks must
   pass before merge
 - **Deploy**: Netlify (`netlify.toml`); build command


### PR DESCRIPTION
## Summary

- Add parallel `typecheck` job to `.github/workflows/ci.yml` running `npm run typecheck` (vue-tsc --noEmit)
- Update FLOW.md Section 3 (CI commands list + Required CI checks) and Section 5 (Required Checks) to include `typecheck`

Closes #20

## Notes

- **Branch protection**: admin must add `typecheck` as a required status check in repo settings after merge
- No `continue-on-error`, no warning cap — gate is binary by design
- `.baseline/typecheck_output.txt` left untouched

## Test plan

- [ ] Confirm `typecheck` check appears in PR checks panel
- [ ] All four checks (`lint`, `format`, `typecheck`, `test`) run in parallel and pass green
- [ ] Gate-proof: deliberate type error on throwaway branch causes `typecheck` to fail red

Generated by flow_ai workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added TypeScript type-checking as a new required CI step, so type checks run alongside lint, format, and tests on each commit.

* **Documentation**
  * Updated development workflow guidance to list type-checking as a required CI check and to reflect the updated set of required verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->