### PR TITLE
chore: promote eslint warn rules to error, drop CI cap to 0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npm run lint -- --max-warnings 153
+      - run: npm run lint -- --max-warnings=0
         timeout-minutes: 5
 
   format:

--- a/FLOW.md
+++ b/FLOW.md
@@ -243,7 +243,7 @@ Agents do NOT duplicate this locally.
 
 - **CI platform**: GitHub Actions
 - **CI commands**:
-  - Lint: `npm run lint -- --max-warnings 153`
+  - Lint: `npm run lint -- --max-warnings=0`
   - Format: `npm run format:check`
   - Typecheck: `npm run typecheck`
   - Tests: `npx vitest run --no-coverage`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,20 +7,9 @@ export default createConfigForNuxt({
 })
   .override('nuxt/typescript/rules', {
     rules: {
-      // Temporary: Allow legacy `any` types (99 instances)
-      // Fix incrementally in future PRs
-      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off',
-      // Temporary: Allow legacy unused vars (19 instances)
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-      // Temporary: Allow legacy dynamic delete (11 instances)
-      '@typescript-eslint/no-dynamic-delete': 'warn',
-      // Temporary: Allow legacy unsafe function types
-      '@typescript-eslint/no-unsafe-function-type': 'warn',
-      // Temporary: Allow legacy useless constructors
-      '@typescript-eslint/no-useless-constructor': 'warn',
-      // Temporary: Allow legacy useless escape characters
-      'no-useless-escape': 'warn',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       'vue/multi-word-component-names': 'off',
       'vue/html-self-closing': [
         'error',

--- a/tests/unit/components/VideoCard.test.ts
+++ b/tests/unit/components/VideoCard.test.ts
@@ -326,53 +326,41 @@ describe('VideoCard', () => {
       expect(chip.attributes('color')).toBe('success')
     })
 
-    it(
-      'should map intermediate level to warning color',
-      () => {
-        const video: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          level: 'intermediate'
-        }
-        const wrapper = mount(VideoCard, {
-          props: { video }
-        })
-        const chip = wrapper.find('ion-chip')
-        expect(chip.attributes('color'))
-          .toBe('warning')
+    it('should map intermediate level to warning color', () => {
+      const video: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        level: 'intermediate'
       }
-    )
+      const wrapper = mount(VideoCard, {
+        props: { video }
+      })
+      const chip = wrapper.find('ion-chip')
+      expect(chip.attributes('color')).toBe('warning')
+    })
 
-    it(
-      'should map advanced level to danger color',
-      () => {
-        const video: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          level: 'advanced'
-        }
-        const wrapper = mount(VideoCard, {
-          props: { video }
-        })
-        const chip = wrapper.find('ion-chip')
-        expect(chip.attributes('color'))
-          .toBe('danger')
+    it('should map advanced level to danger color', () => {
+      const video: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        level: 'advanced'
       }
-    )
+      const wrapper = mount(VideoCard, {
+        props: { video }
+      })
+      const chip = wrapper.find('ion-chip')
+      expect(chip.attributes('color')).toBe('danger')
+    })
 
-    it(
-      'should default to success color for unknown level',
-      () => {
-        const video: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          level: 'expert'
-        }
-        const wrapper = mount(VideoCard, {
-          props: { video }
-        })
-        const chip = wrapper.find('ion-chip')
-        expect(chip.attributes('color'))
-          .toBe('success')
+    it('should default to success color for unknown level', () => {
+      const video: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        level: 'expert'
       }
-    )
+      const wrapper = mount(VideoCard, {
+        props: { video }
+      })
+      const chip = wrapper.find('ion-chip')
+      expect(chip.attributes('color')).toBe('success')
+    })
   })
 
   describe('Edge Cases', () => {

--- a/tests/unit/pages/index.test.ts
+++ b/tests/unit/pages/index.test.ts
@@ -1,21 +1,9 @@
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach
-} from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { onMounted, reactive } from 'vue'
 import { flushPromises } from '../../setup/test-setup'
-import {
-  freeVideoWithQueryParams,
-  premiumVideo
-} from '../../fixtures/videos'
-import type {
-  ContentPublic
-} from '../../../shared/types/api/content.types'
+import { freeVideoWithQueryParams, premiumVideo } from '../../fixtures/videos'
+import type { ContentPublic } from '../../../shared/types/api/content.types'
 
 // Make Vue lifecycle hooks globally available
 // (Nuxt auto-imports these but test-setup omits
@@ -56,18 +44,13 @@ function mountPage(
     apiResult?: unknown
   } = {}
 ) {
-  const {
-    authenticated = false,
-    apiResult = []
-  } = overrides
+  const { authenticated = false, apiResult = [] } = overrides
 
   apiMock.mockResolvedValue(apiResult)
 
-  vi.stubGlobal(
-    'useApi', () => ({ api: apiMock })
-  )
-  vi.stubGlobal(
-    'useAuthStore', () => reactive({
+  vi.stubGlobal('useApi', () => ({ api: apiMock }))
+  vi.stubGlobal('useAuthStore', () =>
+    reactive({
       user: null,
       token: null,
       isAuthenticated: authenticated,
@@ -90,8 +73,7 @@ describe('IndexPage', () => {
 
   beforeEach(() => {
     apiMock.mockReset()
-    randomSpy = vi.spyOn(Math, 'random')
-      .mockReturnValue(0)
+    randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
   })
 
   afterEach(() => {
@@ -103,342 +85,228 @@ describe('IndexPage', () => {
       mountPage({ apiResult: [] })
       await flushPromises()
 
-      expect(apiMock).toHaveBeenCalledWith(
-        '/products/content/public'
-      )
+      expect(apiMock).toHaveBeenCalledWith('/products/content/public')
     })
 
-    it(
-      'filters out videos with null url',
-      async () => {
-        // premiumVideo has url=null, should not
-        // be selected even with Math.random=0
-        // Only freeVideoWithQueryParams qualifies
-        const wrapper = mountPage({
-          apiResult: [
-            premiumVideo,
-            freeVideoWithQueryParams
-          ]
-        })
-        await flushPromises()
+    it('filters out videos with null url', async () => {
+      // premiumVideo has url=null, should not
+      // be selected even with Math.random=0
+      // Only freeVideoWithQueryParams qualifies
+      const wrapper = mountPage({
+        apiResult: [premiumVideo, freeVideoWithQueryParams]
+      })
+      await flushPromises()
 
-        const card = wrapper.findComponent(
-          stubs.VideoCard
-        )
-        expect(card.exists()).toBe(true)
-        expect(card.props('video')._id).toBe(
-          freeVideoWithQueryParams._id
-        )
+      const card = wrapper.findComponent(stubs.VideoCard)
+      expect(card.exists()).toBe(true)
+      expect(card.props('video')._id).toBe(freeVideoWithQueryParams._id)
+    })
+
+    it('filters out non-basic level videos', async () => {
+      const intermediateVideo: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'intermediate-1',
+        level: 'intermediate'
       }
-    )
+      const wrapper = mountPage({
+        apiResult: [intermediateVideo, freeVideoWithQueryParams]
+      })
+      await flushPromises()
 
-    it(
-      'filters out non-basic level videos',
-      async () => {
-        const intermediateVideo: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          _id: 'intermediate-1',
-          level: 'intermediate'
-        }
-        const wrapper = mountPage({
-          apiResult: [
-            intermediateVideo,
-            freeVideoWithQueryParams
-          ]
-        })
-        await flushPromises()
+      const card = wrapper.findComponent(stubs.VideoCard)
+      expect(card.exists()).toBe(true)
+      expect(card.props('video')._id).toBe(freeVideoWithQueryParams._id)
+    })
 
-        const card = wrapper.findComponent(
-          stubs.VideoCard
-        )
-        expect(card.exists()).toBe(true)
-        expect(card.props('video')._id).toBe(
-          freeVideoWithQueryParams._id
-        )
+    it('filters out videos with credits > 0', async () => {
+      const paidBasic: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'paid-basic-1',
+        credits: 5
       }
-    )
+      const wrapper = mountPage({
+        apiResult: [paidBasic, freeVideoWithQueryParams]
+      })
+      await flushPromises()
 
-    it(
-      'filters out videos with credits > 0',
-      async () => {
-        const paidBasic: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          _id: 'paid-basic-1',
-          credits: 5
-        }
-        const wrapper = mountPage({
-          apiResult: [
-            paidBasic,
-            freeVideoWithQueryParams
-          ]
-        })
-        await flushPromises()
+      const card = wrapper.findComponent(stubs.VideoCard)
+      expect(card.exists()).toBe(true)
+      expect(card.props('video')._id).toBe(freeVideoWithQueryParams._id)
+    })
 
-        const card = wrapper.findComponent(
-          stubs.VideoCard
-        )
-        expect(card.exists()).toBe(true)
-        expect(card.props('video')._id).toBe(
-          freeVideoWithQueryParams._id
-        )
+    it('uses Math.random to select from pool', async () => {
+      const second: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'second-free'
       }
-    )
+      randomSpy.mockReturnValue(0.99)
 
-    it(
-      'uses Math.random to select from pool',
-      async () => {
-        const second: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          _id: 'second-free'
-        }
-        randomSpy.mockReturnValue(0.99)
+      const wrapper = mountPage({
+        apiResult: [freeVideoWithQueryParams, second]
+      })
+      await flushPromises()
 
-        const wrapper = mountPage({
-          apiResult: [
-            freeVideoWithQueryParams,
-            second
-          ]
-        })
-        await flushPromises()
-
-        const card = wrapper.findComponent(
-          stubs.VideoCard
-        )
-        expect(card.exists()).toBe(true)
-        // floor(0.99 * 2) = 1 => second video
-        expect(card.props('video')._id).toBe(
-          'second-free'
-        )
-      }
-    )
+      const card = wrapper.findComponent(stubs.VideoCard)
+      expect(card.exists()).toBe(true)
+      // floor(0.99 * 2) = 1 => second video
+      expect(card.props('video')._id).toBe('second-free')
+    })
   })
 
   describe('Display Logic', () => {
-    it(
-      'renders VideoCard with featured=true',
-      async () => {
-        const wrapper = mountPage({
-          apiResult: [freeVideoWithQueryParams]
+    it('renders VideoCard with featured=true', async () => {
+      const wrapper = mountPage({
+        apiResult: [freeVideoWithQueryParams]
+      })
+      await flushPromises()
+
+      const card = wrapper.findComponent(stubs.VideoCard)
+      expect(card.exists()).toBe(true)
+      expect(card.props('featured')).toBe(true)
+    })
+
+    it('View All button links to /tutorials', async () => {
+      const wrapper = mountPage({
+        apiResult: [freeVideoWithQueryParams]
+      })
+      await flushPromises()
+
+      const buttons = wrapper.findAll('ion-button')
+      const viewAll = buttons.find(b => b.text().includes('home.featuredVideo.viewAll'))
+      expect(viewAll).toBeDefined()
+      expect(viewAll!.attributes('router-link')).toBe('/tutorials')
+    })
+
+    it('hides featured section while loading', () => {
+      // Do not await flushPromises so
+      // loadingVideo stays true
+      apiMock.mockReturnValue(new Promise(() => {}))
+      vi.stubGlobal('useApi', () => ({ api: apiMock }))
+      vi.stubGlobal('useAuthStore', () =>
+        reactive({
+          user: null,
+          token: null,
+          isAuthenticated: false,
+          setUser: vi.fn(),
+          setToken: vi.fn(),
+          logout: vi.fn(),
+          $patch: vi.fn(),
+          $reset: vi.fn(),
+          $subscribe: vi.fn()
         })
-        await flushPromises()
+      )
 
-        const card = wrapper.findComponent(
-          stubs.VideoCard
-        )
-        expect(card.exists()).toBe(true)
-        expect(card.props('featured')).toBe(true)
-      }
-    )
+      const wrapper = mount(IndexPage, {
+        global: { stubs }
+      })
 
-    it(
-      'View All button links to /tutorials',
-      async () => {
-        const wrapper = mountPage({
-          apiResult: [freeVideoWithQueryParams]
-        })
-        await flushPromises()
-
-        const buttons = wrapper.findAll(
-          'ion-button'
-        )
-        const viewAll = buttons.find(
-          b => b.text().includes(
-            'home.featuredVideo.viewAll'
-          )
-        )
-        expect(viewAll).toBeDefined()
-        expect(
-          viewAll!.attributes('router-link')
-        ).toBe('/tutorials')
-      }
-    )
-
-    it(
-      'hides featured section while loading',
-      () => {
-        // Do not await flushPromises so
-        // loadingVideo stays true
-        apiMock.mockReturnValue(
-          new Promise(() => {})
-        )
-        vi.stubGlobal(
-          'useApi', () => ({ api: apiMock })
-        )
-        vi.stubGlobal(
-          'useAuthStore', () => reactive({
-            user: null,
-            token: null,
-            isAuthenticated: false,
-            setUser: vi.fn(),
-            setToken: vi.fn(),
-            logout: vi.fn(),
-            $patch: vi.fn(),
-            $reset: vi.fn(),
-            $subscribe: vi.fn()
-          })
-        )
-
-        const wrapper = mount(IndexPage, {
-          global: { stubs }
-        })
-
-        const grid = wrapper.find('.featured-grid')
-        expect(grid.exists()).toBe(false)
-      }
-    )
+      const grid = wrapper.find('.featured-grid')
+      expect(grid.exists()).toBe(false)
+    })
   })
 
   describe('Error Handling', () => {
-    it(
-      'does not show error UI on API failure',
-      async () => {
-        apiMock.mockRejectedValue(
-          new Error('Network error')
-        )
-        vi.stubGlobal(
-          'useApi', () => ({ api: apiMock })
-        )
-        vi.stubGlobal(
-          'useAuthStore', () => reactive({
-            user: null,
-            token: null,
-            isAuthenticated: false,
-            setUser: vi.fn(),
-            setToken: vi.fn(),
-            logout: vi.fn(),
-            $patch: vi.fn(),
-            $reset: vi.fn(),
-            $subscribe: vi.fn()
-          })
-        )
-
-        const wrapper = mount(IndexPage, {
-          global: { stubs }
+    it('does not show error UI on API failure', async () => {
+      apiMock.mockRejectedValue(new Error('Network error'))
+      vi.stubGlobal('useApi', () => ({ api: apiMock }))
+      vi.stubGlobal('useAuthStore', () =>
+        reactive({
+          user: null,
+          token: null,
+          isAuthenticated: false,
+          setUser: vi.fn(),
+          setToken: vi.fn(),
+          logout: vi.fn(),
+          $patch: vi.fn(),
+          $reset: vi.fn(),
+          $subscribe: vi.fn()
         })
-        await flushPromises()
+      )
 
-        expect(
-          wrapper.find('.error').exists()
-        ).toBe(false)
-        expect(
-          wrapper.find('[role="alert"]').exists()
-        ).toBe(false)
-      }
-    )
+      const wrapper = mount(IndexPage, {
+        global: { stubs }
+      })
+      await flushPromises()
 
-    it(
-      'hides featured section on API error',
-      async () => {
-        apiMock.mockRejectedValue(
-          new Error('Server error')
-        )
-        vi.stubGlobal(
-          'useApi', () => ({ api: apiMock })
-        )
-        vi.stubGlobal(
-          'useAuthStore', () => reactive({
-            user: null,
-            token: null,
-            isAuthenticated: false,
-            setUser: vi.fn(),
-            setToken: vi.fn(),
-            logout: vi.fn(),
-            $patch: vi.fn(),
-            $reset: vi.fn(),
-            $subscribe: vi.fn()
-          })
-        )
+      expect(wrapper.find('.error').exists()).toBe(false)
+      expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+    })
 
-        const wrapper = mount(IndexPage, {
-          global: { stubs }
+    it('hides featured section on API error', async () => {
+      apiMock.mockRejectedValue(new Error('Server error'))
+      vi.stubGlobal('useApi', () => ({ api: apiMock }))
+      vi.stubGlobal('useAuthStore', () =>
+        reactive({
+          user: null,
+          token: null,
+          isAuthenticated: false,
+          setUser: vi.fn(),
+          setToken: vi.fn(),
+          logout: vi.fn(),
+          $patch: vi.fn(),
+          $reset: vi.fn(),
+          $subscribe: vi.fn()
         })
-        await flushPromises()
+      )
 
-        expect(
-          wrapper.find('.featured-grid').exists()
-        ).toBe(false)
-      }
-    )
+      const wrapper = mount(IndexPage, {
+        global: { stubs }
+      })
+      await flushPromises()
+
+      expect(wrapper.find('.featured-grid').exists()).toBe(false)
+    })
   })
 
   describe('Authentication States', () => {
-    it(
-      'shows register and login when not auth',
-      async () => {
-        const wrapper = mountPage({
-          authenticated: false,
-          apiResult: []
-        })
-        await flushPromises()
+    it('shows register and login when not auth', async () => {
+      const wrapper = mountPage({
+        authenticated: false,
+        apiResult: []
+      })
+      await flushPromises()
 
-        const text = wrapper.text()
-        expect(text).toContain('home.getStarted')
-        expect(text).toContain('home.signIn')
-        expect(text).not.toContain(
-          'home.manageAccount'
-        )
-      }
-    )
+      const text = wrapper.text()
+      expect(text).toContain('home.getStarted')
+      expect(text).toContain('home.signIn')
+      expect(text).not.toContain('home.manageAccount')
+    })
 
-    it(
-      'shows account button when authenticated',
-      async () => {
-        const wrapper = mountPage({
-          authenticated: true,
-          apiResult: []
-        })
-        await flushPromises()
+    it('shows account button when authenticated', async () => {
+      const wrapper = mountPage({
+        authenticated: true,
+        apiResult: []
+      })
+      await flushPromises()
 
-        const text = wrapper.text()
-        expect(text).toContain(
-          'home.manageAccount'
-        )
-        expect(text).not.toContain(
-          'home.getStarted'
-        )
-        expect(text).not.toContain(
-          'home.signIn'
-        )
-      }
-    )
+      const text = wrapper.text()
+      expect(text).toContain('home.manageAccount')
+      expect(text).not.toContain('home.getStarted')
+      expect(text).not.toContain('home.signIn')
+    })
   })
 
   describe('Edge Cases', () => {
-    it(
-      'no featured video when all premium',
-      async () => {
-        const wrapper = mountPage({
-          apiResult: [premiumVideo]
-        })
-        await flushPromises()
+    it('no featured video when all premium', async () => {
+      const wrapper = mountPage({
+        apiResult: [premiumVideo]
+      })
+      await flushPromises()
 
-        expect(
-          wrapper.find('.featured-grid').exists()
-        ).toBe(false)
-      }
-    )
+      expect(wrapper.find('.featured-grid').exists()).toBe(false)
+    })
 
-    it(
-      'selects the only matching video',
-      async () => {
-        randomSpy.mockReturnValue(0)
+    it('selects the only matching video', async () => {
+      randomSpy.mockReturnValue(0)
 
-        const wrapper = mountPage({
-          apiResult: [
-            premiumVideo,
-            freeVideoWithQueryParams
-          ]
-        })
-        await flushPromises()
+      const wrapper = mountPage({
+        apiResult: [premiumVideo, freeVideoWithQueryParams]
+      })
+      await flushPromises()
 
-        const card = wrapper.findComponent(
-          stubs.VideoCard
-        )
-        expect(card.exists()).toBe(true)
-        expect(card.props('video')._id).toBe(
-          freeVideoWithQueryParams._id
-        )
-      }
-    )
+      const card = wrapper.findComponent(stubs.VideoCard)
+      expect(card.exists()).toBe(true)
+      expect(card.props('video')._id).toBe(freeVideoWithQueryParams._id)
+    })
   })
 })

--- a/tests/unit/pages/tutorials.test.ts
+++ b/tests/unit/pages/tutorials.test.ts
@@ -1,21 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 import type { VueWrapper } from '@vue/test-utils'
-import {
-  onMounted,
-  onUnmounted,
-  onBeforeMount,
-  onBeforeUnmount
-} from 'vue'
+import { onMounted, onUnmounted, onBeforeMount, onBeforeUnmount } from 'vue'
 import { flushPromises } from '../../setup/test-setup'
-import type { ContentPublic } from
-  '../../../shared/types/api/content.types'
+import type { ContentPublic } from '../../../shared/types/api/content.types'
 import {
   freeVideoWithQueryParams,
   freeVideoNoQueryParams,
   premiumVideo,
   allVideos
 } from '../../fixtures/videos'
+
+/**
+ * Typed subset of TutorialsPage vm for test access.
+ */
+interface TutorialsVm {
+  searchQuery: string
+  filteredVideos: ContentPublic[]
+  selectedCategoryTags: string[]
+  selectedLevels: string[]
+  selectedProfileTags: string[]
+  sortBy: string
+  sortDirection: string
+  availableCategoryTags: string[]
+  availableProfileTags: string[]
+}
 
 // Make Vue lifecycle hooks available as globals
 // so compiled SFC code can reference them
@@ -28,13 +37,10 @@ vi.stubGlobal('onBeforeUnmount', onBeforeUnmount)
 vi.stubGlobal('definePageMeta', vi.fn())
 
 // Import page after globals are set (top-level await)
-const { default: TutorialsPage } =
-  await import('~/pages/tutorials.vue')
+const { default: TutorialsPage } = await import('~/pages/tutorials.vue')
 
 // Helper: videos with non-null URLs from allVideos
-const videosWithUrls = allVideos.filter(
-  v => v.url !== null
-)
+const videosWithUrls = allVideos.filter(v => v.url !== null)
 
 /**
  * Mount tutorials page with a mocked API response.
@@ -42,37 +48,31 @@ const videosWithUrls = allVideos.filter(
  * Pass `apiResponse` to override, or `apiError` to
  * simulate a failure.
  */
-async function mountPage(opts: {
-  apiResponse?: ContentPublic[]
-  apiError?: boolean
-  skipFlush?: boolean
-} = {}): Promise<{
+async function mountPage(
+  opts: {
+    apiResponse?: ContentPublic[]
+    apiError?: boolean
+    skipFlush?: boolean
+  } = {}
+): Promise<{
   wrapper: VueWrapper
   mockApi: ReturnType<typeof vi.fn>
 }> {
   const mockApi = vi.fn()
 
   if (opts.apiError) {
-    mockApi.mockRejectedValueOnce(
-      new Error('Network error')
-    )
+    mockApi.mockRejectedValueOnce(new Error('Network error'))
   } else {
-    mockApi.mockResolvedValueOnce(
-      opts.apiResponse ?? allVideos
-    )
+    mockApi.mockResolvedValueOnce(opts.apiResponse ?? allVideos)
   }
 
-  vi.stubGlobal(
-    'useApi',
-    () => ({ api: mockApi })
-  )
+  vi.stubGlobal('useApi', () => ({ api: mockApi }))
 
   const wrapper = mount(TutorialsPage, {
     global: {
       stubs: {
         LoadingSpinner: {
-          template:
-            '<div class="loading-stub">loading</div>'
+          template: '<div class="loading-stub">loading</div>'
         },
         ErrorCard: {
           template:
@@ -83,9 +83,7 @@ async function mountPage(opts: {
           inheritAttrs: false
         },
         VideoCard: {
-          template:
-            '<div class="video-card-stub">' +
-            '{{ video.title }}</div>',
+          template: '<div class="video-card-stub">' + '{{ video.title }}</div>',
           props: ['video']
         }
       }
@@ -109,115 +107,87 @@ describe('TutorialsPage', () => {
   // 1. API Integration
   // -----------------------------------------------
   describe('API Integration', () => {
-    it('calls API on mount with correct endpoint',
-      async () => {
-        const { mockApi } = await mountPage()
-        expect(mockApi).toHaveBeenCalledWith(
-          '/products/content/public'
-        )
-      }
-    )
+    it('calls API on mount with correct endpoint', async () => {
+      const { mockApi } = await mountPage()
+      expect(mockApi).toHaveBeenCalledWith('/products/content/public')
+    })
 
-    it('shows loading state before API resolves',
-      async () => {
-        const { wrapper } = await mountPage({
-          skipFlush: true
-        })
-        expect(
-          wrapper.find('.loading-stub').exists()
-        ).toBe(true)
-      }
-    )
+    it('shows loading state before API resolves', async () => {
+      const { wrapper } = await mountPage({
+        skipFlush: true
+      })
+      expect(wrapper.find('.loading-stub').exists()).toBe(true)
+    })
 
-    it('shows error state on API failure with retry',
-      async () => {
-        const { wrapper, mockApi } = await mountPage({
-          apiError: true
-        })
+    it('shows error state on API failure with retry', async () => {
+      const { wrapper, mockApi } = await mountPage({
+        apiError: true
+      })
 
-        expect(
-          wrapper.find('.error-stub').exists()
-        ).toBe(true)
+      expect(wrapper.find('.error-stub').exists()).toBe(true)
 
-        // Setup a successful retry
-        mockApi.mockResolvedValueOnce(allVideos)
-        await wrapper.find('.retry').trigger('click')
-        await flushPromises()
+      // Setup a successful retry
+      mockApi.mockResolvedValueOnce(allVideos)
+      await wrapper.find('.retry').trigger('click')
+      await flushPromises()
 
-        expect(
-          wrapper.find('.error-stub').exists()
-        ).toBe(false)
-        expect(mockApi).toHaveBeenCalledTimes(2)
-      }
-    )
+      expect(wrapper.find('.error-stub').exists()).toBe(false)
+      expect(mockApi).toHaveBeenCalledTimes(2)
+    })
   })
 
   // -----------------------------------------------
   // 2. Search Filtering
   // -----------------------------------------------
   describe('Search Filtering', () => {
-    it('filters by title case-insensitively',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.searchQuery = 'breeding basics'
-        await wrapper.vm.$nextTick()
+    it('filters by title case-insensitively', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.searchQuery = 'breeding basics'
+      await wrapper.vm.$nextTick()
 
-        const filtered = vm.filteredVideos
-        expect(filtered.length).toBeGreaterThan(0)
-        expect(
-          filtered.every((v: ContentPublic) =>
-            v.title.toLowerCase()
-              .includes('breeding basics')
-          )
-        ).toBe(true)
-      }
-    )
+      const filtered = vm.filteredVideos
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(
+        filtered.every((v: ContentPublic) => v.title.toLowerCase().includes('breeding basics'))
+      ).toBe(true)
+    })
 
-    it('filters by description case-insensitively',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.searchQuery = 'FUNDAMENTALS'
-        await wrapper.vm.$nextTick()
+    it('filters by description case-insensitively', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.searchQuery = 'FUNDAMENTALS'
+      await wrapper.vm.$nextTick()
 
-        const filtered = vm.filteredVideos
-        expect(filtered.length).toBeGreaterThan(0)
-        expect(
-          filtered.every((v: ContentPublic) =>
-            v.title.toLowerCase()
-              .includes('fundamentals') ||
-            v.description.toLowerCase()
-              .includes('fundamentals')
-          )
-        ).toBe(true)
-      }
-    )
-
-    it('shows all videos when search is empty',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.searchQuery = ''
-        await wrapper.vm.$nextTick()
-
-        expect(vm.filteredVideos.length).toBe(
-          videosWithUrls.length
+      const filtered = vm.filteredVideos
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(
+        filtered.every(
+          (v: ContentPublic) =>
+            v.title.toLowerCase().includes('fundamentals') ||
+            v.description.toLowerCase().includes('fundamentals')
         )
-      }
-    )
+      ).toBe(true)
+    })
 
-    it('handles special characters without crash',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.searchQuery = '.*+?^${}()|[]\\'
-        await wrapper.vm.$nextTick()
+    it('shows all videos when search is empty', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.searchQuery = ''
+      await wrapper.vm.$nextTick()
 
-        // Should not throw; may return 0 results
-        expect(vm.filteredVideos).toBeDefined()
-      }
-    )
+      expect(vm.filteredVideos.length).toBe(videosWithUrls.length)
+    })
+
+    it('handles special characters without crash', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.searchQuery = '.*+?^${}()|[]\\'
+      await wrapper.vm.$nextTick()
+
+      // Should not throw; may return 0 results
+      expect(vm.filteredVideos).toBeDefined()
+    })
   })
 
   // -----------------------------------------------
@@ -226,50 +196,39 @@ describe('TutorialsPage', () => {
   describe('Level Filtering', () => {
     it('filters by a single level', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.selectedLevels = ['basic']
       await wrapper.vm.$nextTick()
 
       const filtered = vm.filteredVideos
       expect(filtered.length).toBeGreaterThan(0)
-      expect(
-        filtered.every(
-          (v: ContentPublic) => v.level === 'basic'
-        )
-      ).toBe(true)
+      expect(filtered.every((v: ContentPublic) => v.level === 'basic')).toBe(true)
     })
 
-    it('filters by multiple levels (OR)',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.selectedLevels = ['basic', 'advanced']
-        await wrapper.vm.$nextTick()
+    it('filters by multiple levels (OR)', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.selectedLevels = ['basic', 'advanced']
+      await wrapper.vm.$nextTick()
 
-        const filtered = vm.filteredVideos
-        expect(filtered.length).toBeGreaterThan(0)
-        expect(
-          filtered.every((v: ContentPublic) =>
-            ['basic', 'advanced'].includes(v.level)
-          )
-        ).toBe(true)
-      }
-    )
+      const filtered = vm.filteredVideos
+      expect(filtered.length).toBeGreaterThan(0)
+      expect(filtered.every((v: ContentPublic) => ['basic', 'advanced'].includes(v.level))).toBe(
+        true
+      )
+    })
 
-    it('restores all when filter is cleared',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.selectedLevels = ['basic']
-        await wrapper.vm.$nextTick()
-        const countWithFilter = vm.filteredVideos.length
+    it('restores all when filter is cleared', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.selectedLevels = ['basic']
+      await wrapper.vm.$nextTick()
+      const countWithFilter = vm.filteredVideos.length
 
-        vm.selectedLevels = []
-        await wrapper.vm.$nextTick()
-        expect(vm.filteredVideos.length)
-          .toBeGreaterThan(countWithFilter)
-      }
-    )
+      vm.selectedLevels = []
+      await wrapper.vm.$nextTick()
+      expect(vm.filteredVideos.length).toBeGreaterThan(countWithFilter)
+    })
   })
 
   // -----------------------------------------------
@@ -278,7 +237,7 @@ describe('TutorialsPage', () => {
   describe('Tag Filtering', () => {
     it('category tags use OR logic', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.selectedCategoryTags = ['breeding', 'rearing']
       await wrapper.vm.$nextTick()
 
@@ -286,16 +245,14 @@ describe('TutorialsPage', () => {
       expect(filtered.length).toBeGreaterThan(0)
       expect(
         filtered.every((v: ContentPublic) =>
-          v.category_tags.some(
-            t => ['breeding', 'rearing'].includes(t)
-          )
+          v.category_tags.some(t => ['breeding', 'rearing'].includes(t))
         )
       ).toBe(true)
     })
 
     it('profile tags use OR logic', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.selectedProfileTags = ['newbie', 'business']
       await wrapper.vm.$nextTick()
 
@@ -303,30 +260,25 @@ describe('TutorialsPage', () => {
       expect(filtered.length).toBeGreaterThan(0)
       expect(
         filtered.every((v: ContentPublic) =>
-          v.profile_tags.some(
-            t => ['newbie', 'business'].includes(t)
-          )
+          v.profile_tags.some(t => ['newbie', 'business'].includes(t))
         )
       ).toBe(true)
     })
 
-    it('combines level + tags with AND logic',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.selectedLevels = ['basic']
-        vm.selectedCategoryTags = ['breeding']
-        await wrapper.vm.$nextTick()
+    it('combines level + tags with AND logic', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.selectedLevels = ['basic']
+      vm.selectedCategoryTags = ['breeding']
+      await wrapper.vm.$nextTick()
 
-        const filtered = vm.filteredVideos
-        expect(
-          filtered.every((v: ContentPublic) =>
-            v.level === 'basic' &&
-            v.category_tags.includes('breeding')
-          )
-        ).toBe(true)
-      }
-    )
+      const filtered = vm.filteredVideos
+      expect(
+        filtered.every(
+          (v: ContentPublic) => v.level === 'basic' && v.category_tags.includes('breeding')
+        )
+      ).toBe(true)
+    })
   })
 
   // -----------------------------------------------
@@ -335,105 +287,79 @@ describe('TutorialsPage', () => {
   describe('Sorting', () => {
     it('sorts by credits ascending', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.sortBy = 'credits'
       vm.sortDirection = 'asc'
       await wrapper.vm.$nextTick()
 
-      const credits = vm.filteredVideos.map(
-        (v: ContentPublic) => v.credits
-      )
+      const credits = vm.filteredVideos.map((v: ContentPublic) => v.credits)
       for (let i = 1; i < credits.length; i++) {
-        expect(credits[i]).toBeGreaterThanOrEqual(
-          credits[i - 1]
-        )
+        expect(credits[i]).toBeGreaterThanOrEqual(credits[i - 1])
       }
     })
 
     it('sorts by credits descending', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.sortBy = 'credits'
       vm.sortDirection = 'desc'
       await wrapper.vm.$nextTick()
 
-      const credits = vm.filteredVideos.map(
-        (v: ContentPublic) => v.credits
-      )
+      const credits = vm.filteredVideos.map((v: ContentPublic) => v.credits)
       for (let i = 1; i < credits.length; i++) {
-        expect(credits[i]).toBeLessThanOrEqual(
-          credits[i - 1]
-        )
+        expect(credits[i]).toBeLessThanOrEqual(credits[i - 1])
       }
     })
 
     it('sorts by title ascending', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.sortBy = 'title'
       vm.sortDirection = 'asc'
       await wrapper.vm.$nextTick()
 
-      const titles = vm.filteredVideos.map(
-        (v: ContentPublic) => v.title
-      )
+      const titles = vm.filteredVideos.map((v: ContentPublic) => v.title)
       for (let i = 1; i < titles.length; i++) {
-        expect(
-          titles[i].localeCompare(titles[i - 1])
-        ).toBeGreaterThanOrEqual(0)
+        expect(titles[i].localeCompare(titles[i - 1])).toBeGreaterThanOrEqual(0)
       }
     })
 
     it('sorts by title descending', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.sortBy = 'title'
       vm.sortDirection = 'desc'
       await wrapper.vm.$nextTick()
 
-      const titles = vm.filteredVideos.map(
-        (v: ContentPublic) => v.title
-      )
+      const titles = vm.filteredVideos.map((v: ContentPublic) => v.title)
       for (let i = 1; i < titles.length; i++) {
-        expect(
-          titles[i].localeCompare(titles[i - 1])
-        ).toBeLessThanOrEqual(0)
+        expect(titles[i].localeCompare(titles[i - 1])).toBeLessThanOrEqual(0)
       }
     })
 
     it('sorts by date ascending', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.sortBy = 'date'
       vm.sortDirection = 'asc'
       await wrapper.vm.$nextTick()
 
-      const dates = vm.filteredVideos.map(
-        (v: ContentPublic) =>
-          new Date(v.created_at).getTime()
-      )
+      const dates = vm.filteredVideos.map((v: ContentPublic) => new Date(v.created_at).getTime())
       for (let i = 1; i < dates.length; i++) {
-        expect(dates[i]).toBeGreaterThanOrEqual(
-          dates[i - 1]
-        )
+        expect(dates[i]).toBeGreaterThanOrEqual(dates[i - 1])
       }
     })
 
     it('sorts by date descending', async () => {
       const { wrapper } = await mountPage()
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
       vm.sortBy = 'date'
       vm.sortDirection = 'desc'
       await wrapper.vm.$nextTick()
 
-      const dates = vm.filteredVideos.map(
-        (v: ContentPublic) =>
-          new Date(v.created_at).getTime()
-      )
+      const dates = vm.filteredVideos.map((v: ContentPublic) => new Date(v.created_at).getTime())
       for (let i = 1; i < dates.length; i++) {
-        expect(dates[i]).toBeLessThanOrEqual(
-          dates[i - 1]
-        )
+        expect(dates[i]).toBeLessThanOrEqual(dates[i - 1])
       }
     })
   })
@@ -442,99 +368,70 @@ describe('TutorialsPage', () => {
   // 6. Tag Extraction
   // -----------------------------------------------
   describe('Tag Extraction', () => {
-    it('extracts unique sorted category tags',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        const tags = vm.availableCategoryTags
+    it('extracts unique sorted category tags', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      const tags = vm.availableCategoryTags
 
-        // Should be sorted
-        for (let i = 1; i < tags.length; i++) {
-          expect(
-            tags[i].localeCompare(tags[i - 1])
-          ).toBeGreaterThanOrEqual(0)
-        }
-        // Should be unique
-        expect(tags.length).toBe(
-          new Set(tags).size
-        )
+      // Should be sorted
+      for (let i = 1; i < tags.length; i++) {
+        expect(tags[i].localeCompare(tags[i - 1])).toBeGreaterThanOrEqual(0)
       }
-    )
+      // Should be unique
+      expect(tags.length).toBe(new Set(tags).size)
+    })
 
-    it('extracts unique sorted profile tags',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        const tags = vm.availableProfileTags
+    it('extracts unique sorted profile tags', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      const tags = vm.availableProfileTags
 
-        // Should be sorted
-        for (let i = 1; i < tags.length; i++) {
-          expect(
-            tags[i].localeCompare(tags[i - 1])
-          ).toBeGreaterThanOrEqual(0)
-        }
-        // Should be unique
-        expect(tags.length).toBe(
-          new Set(tags).size
-        )
+      // Should be sorted
+      for (let i = 1; i < tags.length; i++) {
+        expect(tags[i].localeCompare(tags[i - 1])).toBeGreaterThanOrEqual(0)
       }
-    )
+      // Should be unique
+      expect(tags.length).toBe(new Set(tags).size)
+    })
   })
 
   // -----------------------------------------------
   // 7. States
   // -----------------------------------------------
   describe('States', () => {
-    it('shows empty state when no videos match',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        vm.searchQuery = 'zzz_no_match_ever_zzz'
-        await wrapper.vm.$nextTick()
+    it('shows empty state when no videos match', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.searchQuery = 'zzz_no_match_ever_zzz'
+      await wrapper.vm.$nextTick()
 
-        expect(vm.filteredVideos.length).toBe(0)
-        expect(
-          wrapper.text()
-        ).toContain('tutorials.empty.title')
-      }
-    )
+      expect(vm.filteredVideos.length).toBe(0)
+      expect(wrapper.text()).toContain('tutorials.empty.title')
+    })
 
-    it('results count updates with filtering',
-      async () => {
-        const { wrapper } = await mountPage()
-        const vm = wrapper.vm as any
-        const allCount = vm.filteredVideos.length
+    it('results count updates with filtering', async () => {
+      const { wrapper } = await mountPage()
+      const vm = wrapper.vm as unknown as TutorialsVm
+      const allCount = vm.filteredVideos.length
 
-        vm.selectedLevels = ['advanced']
-        await wrapper.vm.$nextTick()
-        const filteredCount = vm.filteredVideos.length
+      vm.selectedLevels = ['advanced']
+      await wrapper.vm.$nextTick()
+      const filteredCount = vm.filteredVideos.length
 
-        expect(filteredCount).toBeLessThan(allCount)
-        expect(
-          wrapper.find('.results-count').exists()
-        ).toBe(true)
-      }
-    )
+      expect(filteredCount).toBeLessThan(allCount)
+      expect(wrapper.find('.results-count').exists()).toBe(true)
+    })
 
-    it('filters out videos with url=null',
-      async () => {
-        const { wrapper } = await mountPage({
-          apiResponse: [
-            freeVideoWithQueryParams,
-            premiumVideo
-          ]
-        })
-        const vm = wrapper.vm as any
+    it('filters out videos with url=null', async () => {
+      const { wrapper } = await mountPage({
+        apiResponse: [freeVideoWithQueryParams, premiumVideo]
+      })
+      const vm = wrapper.vm as unknown as TutorialsVm
 
-        // premiumVideo has url: null
-        expect(vm.filteredVideos.length).toBe(1)
-        expect(
-          vm.filteredVideos.every(
-            (v: ContentPublic) => v.url !== null
-          )
-        ).toBe(true)
-      }
-    )
+      // premiumVideo has url: null
+      expect(vm.filteredVideos.length).toBe(1)
+      expect(vm.filteredVideos.every((v: ContentPublic) => v.url !== null)).toBe(true)
+    })
   })
 
   // -----------------------------------------------
@@ -545,62 +442,48 @@ describe('TutorialsPage', () => {
       const { wrapper } = await mountPage({
         apiResponse: []
       })
-      const vm = wrapper.vm as any
+      const vm = wrapper.vm as unknown as TutorialsVm
 
       expect(vm.filteredVideos.length).toBe(0)
-      expect(
-        wrapper.find('.error-stub').exists()
-      ).toBe(false)
+      expect(wrapper.find('.error-stub').exists()).toBe(false)
     })
 
-    it('searches safely with null title/description',
-      async () => {
-        const nullFieldVideo: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          _id: 'null-fields',
-          title: null as unknown as string,
-          description: null as unknown as string
-        }
-
-        const { wrapper } = await mountPage({
-          apiResponse: [
-            freeVideoWithQueryParams,
-            nullFieldVideo
-          ]
-        })
-        const vm = wrapper.vm as any
-        vm.searchQuery = 'breeding'
-        await wrapper.vm.$nextTick()
-
-        // Should not throw
-        expect(vm.filteredVideos).toBeDefined()
+    it('searches safely with null title/description', async () => {
+      const nullFieldVideo: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'null-fields',
+        title: null as unknown as string,
+        description: null as unknown as string
       }
-    )
 
-    it('sorts by date with missing created_at',
-      async () => {
-        const noDateVideo: ContentPublic = {
-          ...freeVideoWithQueryParams,
-          _id: 'no-date',
-          created_at: '' as string
-        }
+      const { wrapper } = await mountPage({
+        apiResponse: [freeVideoWithQueryParams, nullFieldVideo]
+      })
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.searchQuery = 'breeding'
+      await wrapper.vm.$nextTick()
 
-        const { wrapper } = await mountPage({
-          apiResponse: [
-            freeVideoNoQueryParams,
-            noDateVideo
-          ]
-        })
-        const vm = wrapper.vm as any
-        vm.sortBy = 'date'
-        vm.sortDirection = 'asc'
-        await wrapper.vm.$nextTick()
+      // Should not throw
+      expect(vm.filteredVideos).toBeDefined()
+    })
 
-        // Should not throw
-        expect(
-          vm.filteredVideos.length
-        ).toBeGreaterThan(0)
+    it('sorts by date with missing created_at', async () => {
+      const noDateVideo: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'no-date',
+        created_at: '' as string
       }
-    )
+
+      const { wrapper } = await mountPage({
+        apiResponse: [freeVideoNoQueryParams, noDateVideo]
+      })
+      const vm = wrapper.vm as unknown as TutorialsVm
+      vm.sortBy = 'date'
+      vm.sortDirection = 'asc'
+      await wrapper.vm.$nextTick()
+
+      // Should not throw
+      expect(vm.filteredVideos.length).toBeGreaterThan(0)
+    })
   })
 })


### PR DESCRIPTION
## Summary

- Promote `no-explicit-any` and `no-unused-vars` from `warn` to `error` in `eslint.config.mjs`
- Remove 4 rules (`no-dynamic-delete`, `no-unsafe-function-type`, `no-useless-constructor`, `no-useless-escape`) that default to `error` in the recommended preset
- Delete all 6 "Temporary" comments from `eslint.config.mjs`
- Change CI lint cap from `--max-warnings 153` to `--max-warnings=0`
- Update `FLOW.md` to reflect the new lint command

Closes #22

## Test plan

- [x] `npm run lint` exits 0 with 0 errors, 0 warnings
- [ ] CI `lint` job passes on this PR
- [ ] Manual spot-check: adding `const x: any = 1` to an app file causes lint failure (do not commit)

Generated by flow_ai workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reinforced code quality by making linting stricter (warnings now treated as errors).
  * Tightened TypeScript lint rules to enforce fewer allowed patterns.

* **Documentation**
  * Updated CI guidance to reflect zero-tolerance for lint warnings.

* **Tests**
  * Reformatted and tightened unit tests and added stronger test typings; no behavioral changes to tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->