### PR TITLE
chore: enforce vitest coverage thresholds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
-      - run: npx vitest run --no-coverage
+      - run: npx vitest run --coverage
         timeout-minutes: 10
 
   typecheck:

--- a/FLOW.md
+++ b/FLOW.md
@@ -194,9 +194,9 @@ guidance, data access rules, and Nuxt client/server rules.
 ### Testing Requirements
 
 - **Test Framework**: Vitest (unit), Playwright (e2e)
-- **Coverage Target**: Not enforced globally; aim for meaningful
-  coverage on composables, stores, repositories, and utils.
-  Critical user flows covered by Playwright e2e.
+- **Coverage Target**: Enforced globally via vitest.config.mjs
+  thresholds (lines 25%, branches 78%, functions 72%,
+  statements 25%). CI fails if coverage drops below baseline.
 - **Test Location**: `tests/` directory
   - Unit: `tests/unit/` (mirrors `app/` structure)
   - E2E: `tests/e2e/`
@@ -246,7 +246,7 @@ Agents do NOT duplicate this locally.
   - Lint: `npm run lint -- --max-warnings=0`
   - Format: `npm run format:check`
   - Typecheck: `npm run typecheck`
-  - Tests: `npx vitest run --no-coverage`
+  - Tests: `npx vitest run --coverage`
 - **CI workflow file**: `.github/workflows/ci.yml`
 - **Required CI checks**: `lint`, `format`, `typecheck`, `test`
 - **Note**: Playwright e2e tests do NOT run in CI; they are

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -29,7 +29,13 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['node_modules/**', 'tests/**', '**/*.config.*', '.nuxt/**', 'dist/**']
+      exclude: ['node_modules/**', 'tests/**', '**/*.config.*', '.nuxt/**', 'dist/**'],
+      thresholds: {
+        lines: 25,
+        branches: 78,
+        functions: 72,
+        statements: 25,
+      },
     }
   },
   resolve: {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -34,8 +34,8 @@ export default defineConfig({
         lines: 25,
         branches: 78,
         functions: 72,
-        statements: 25,
-      },
+        statements: 25
+      }
     }
   },
   resolve: {


### PR DESCRIPTION
## Summary

- Add global coverage thresholds to `vitest.config.mjs` based on current baseline (lines 25%, branches 78%, functions 72%, statements 25%)
- Enable coverage collection in CI by changing `--no-coverage` to `--coverage` in the test job
- Update FLOW.md to reflect coverage enforcement

## Coverage Baseline

| Metric | Actual | Threshold |
|--------|--------|-----------|
| Lines | 25.6% | 25% |
| Branches | 78.63% | 78% |
| Functions | 72.32% | 72% |
| Statements | 25.6% | 25% |

Thresholds rounded down to nearest whole percent from `npm run test:coverage` output.

## Test plan

- [x] `npm run test:coverage` passes locally with thresholds
- [ ] CI test job passes with coverage enabled
- [ ] Verify removing a test causes threshold failure (manual spot-check)

Closes #28

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled test coverage collection in CI so coverage is measured during test runs.
  * Enforced global minimum coverage thresholds (lines, branches, functions, statements) so CI fails if coverage falls below baseline.
  * Updated project guidance to align local/CI test commands with enforced coverage policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->