### PR TITLE
refactor: align API layer with repository+service pattern

### DIFF
--- a/app/composables/api/index.ts
+++ b/app/composables/api/index.ts
@@ -1,6 +1,7 @@
 // Export repositories
 export { BaseRepository } from './repositories/BaseRepository'
 export { AuthRepository } from './repositories/AuthRepository'
+export { ContentRepository } from './repositories/ContentRepository'
 export { UserRepository } from './repositories/UserRepository'
 
 // Export services

--- a/app/composables/api/repositories/AuthRepository.ts
+++ b/app/composables/api/repositories/AuthRepository.ts
@@ -9,23 +9,17 @@ import type {
 import { BaseRepository } from './BaseRepository'
 
 export class AuthRepository extends BaseRepository {
-  /**
-   * Login user with email and password using new /auth/login endpoint
-   */
   async login(credentials: LoginRequest): Promise<LoginResponse> {
     const endpoints = useApiEndpoints()
-
-    // Use new /auth/login endpoint with JSON body
     return await this.post<LoginResponse>(endpoints.authLogin, {
       email: credentials.email,
       password: credentials.password
     })
   }
 
-  /**
-   * Register new user using new /auth/register endpoint
-   */
-  async register(userData: RegisterRequest): Promise<RegisterResponse> {
+  async register(
+    userData: RegisterRequest
+  ): Promise<RegisterResponse> {
     const endpoints = useApiEndpoints()
     const { public: runtimePublicConfig } = useRuntimeConfig()
     const domainAlias = runtimePublicConfig?.domainAlias
@@ -33,79 +27,76 @@ export class AuthRepository extends BaseRepository {
     return this.request<RegisterResponse>(endpoints.authRegister, {
       method: 'POST',
       body: userData,
-      query: domainAlias ? { domain_alias: domainAlias } : undefined
+      query: domainAlias
+        ? { domain_alias: domainAlias }
+        : undefined
     })
   }
 
-  /**
-   * Logout user
-   */
-  async logout(): Promise<void> {
-    return this.post('/auth/logout')
-  }
-
-  /**
-   * Refresh access token
-   */
-  async refreshToken(refreshData: RefreshTokenRequest): Promise<RefreshTokenResponse> {
-    return this.post<RefreshTokenResponse>('/auth/refresh', refreshData)
-  }
-
-  /**
-   * Send password reset email using new /auth/reset-password endpoint
-   */
-  async sendPasswordReset(email: string): Promise<{ message: string }> {
+  async refreshToken(
+    refreshData: RefreshTokenRequest
+  ): Promise<RefreshTokenResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(endpoints.authResetPassword, {
-      email
-    })
+    return this.post<RefreshTokenResponse>(
+      endpoints.authRefresh,
+      refreshData
+    )
   }
 
-  /**
-   * Confirm password reset using new /auth/reset-password/confirm endpoint
-   */
-  async confirmPasswordReset(token: string, newPassword: string): Promise<{ message: string }> {
+  async sendPasswordReset(
+    email: string
+  ): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(endpoints.authResetPasswordConfirm, {
-      token,
-      new_password: newPassword
-    })
+    return this.post<{ message: string }>(
+      endpoints.authResetPassword,
+      { email }
+    )
   }
 
-  /**
-   * Reset password for logged-in user using /users/reset_password endpoint
-   */
-  async resetUserPassword(
-    currentPassword: string,
+  async confirmPasswordReset(
+    token: string,
     newPassword: string
   ): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(endpoints.usersResetPassword, {
-      current_password: currentPassword,
-      new_password: newPassword
-    })
+    return this.post<{ message: string }>(
+      endpoints.authResetPasswordConfirm,
+      { token, new_password: newPassword }
+    )
   }
 
-  /**
-   * Verify email with token using new /auth/register/verify endpoint
-   *
-   * @param token - Email verification token from URL
-   * @returns User object with auth tokens on successful verification
-   *
-   * @note API returns HTTP 201 (Created) on success. $fetch
-   *       automatically treats both 200 and 201 as success,
-   *       ensuring backward compatibility during API transition.
-   */
+  async resetUserPassword(
+    newPassword: string
+  ): Promise<{ message: string }> {
+    const endpoints = useApiEndpoints()
+    return this.post<{ message: string }>(
+      endpoints.usersResetPassword,
+      { new_password: newPassword }
+    )
+  }
+
+  async sendRegisterToken(
+    email: string
+  ): Promise<{ message: string }> {
+    const endpoints = useApiEndpoints()
+    return this.post<{ message: string }>(
+      endpoints.authSendToken,
+      { email, token_type: 'register' }
+    )
+  }
+
   async verifyEmail(token: string): Promise<LoginResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<LoginResponse>(endpoints.authRegisterVerify, { token })
+    return this.post<LoginResponse>(
+      endpoints.authRegisterVerify,
+      { token }
+    )
   }
 
-  /**
-   * Login with email token (passwordless login)
-   */
   async loginWithToken(token: string): Promise<LoginResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<LoginResponse>(endpoints.authLoginToken, { token })
+    return this.post<LoginResponse>(
+      endpoints.authLoginToken,
+      { token }
+    )
   }
 }

--- a/app/composables/api/repositories/AuthRepository.ts
+++ b/app/composables/api/repositories/AuthRepository.ts
@@ -17,9 +17,7 @@ export class AuthRepository extends BaseRepository {
     })
   }
 
-  async register(
-    userData: RegisterRequest
-  ): Promise<RegisterResponse> {
+  async register(userData: RegisterRequest): Promise<RegisterResponse> {
     const endpoints = useApiEndpoints()
     const { public: runtimePublicConfig } = useRuntimeConfig()
     const domainAlias = runtimePublicConfig?.domainAlias
@@ -27,76 +25,50 @@ export class AuthRepository extends BaseRepository {
     return this.request<RegisterResponse>(endpoints.authRegister, {
       method: 'POST',
       body: userData,
-      query: domainAlias
-        ? { domain_alias: domainAlias }
-        : undefined
+      query: domainAlias ? { domain_alias: domainAlias } : undefined
     })
   }
 
-  async refreshToken(
-    refreshData: RefreshTokenRequest
-  ): Promise<RefreshTokenResponse> {
+  async refreshToken(refreshData: RefreshTokenRequest): Promise<RefreshTokenResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<RefreshTokenResponse>(
-      endpoints.authRefresh,
-      refreshData
-    )
+    return this.post<RefreshTokenResponse>(endpoints.authRefresh, refreshData)
   }
 
-  async sendPasswordReset(
-    email: string
-  ): Promise<{ message: string }> {
+  async sendPasswordReset(email: string): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(
-      endpoints.authResetPassword,
-      { email }
-    )
+    return this.post<{ message: string }>(endpoints.authResetPassword, { email })
   }
 
-  async confirmPasswordReset(
-    token: string,
-    newPassword: string
-  ): Promise<{ message: string }> {
+  async confirmPasswordReset(token: string, newPassword: string): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(
-      endpoints.authResetPasswordConfirm,
-      { token, new_password: newPassword }
-    )
+    return this.post<{ message: string }>(endpoints.authResetPasswordConfirm, {
+      token,
+      new_password: newPassword
+    })
   }
 
-  async resetUserPassword(
-    newPassword: string
-  ): Promise<{ message: string }> {
+  async resetUserPassword(newPassword: string): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(
-      endpoints.usersResetPassword,
-      { new_password: newPassword }
-    )
+    return this.post<{ message: string }>(endpoints.usersResetPassword, {
+      new_password: newPassword
+    })
   }
 
-  async sendRegisterToken(
-    email: string
-  ): Promise<{ message: string }> {
+  async sendRegisterToken(email: string): Promise<{ message: string }> {
     const endpoints = useApiEndpoints()
-    return this.post<{ message: string }>(
-      endpoints.authSendToken,
-      { email, token_type: 'register' }
-    )
+    return this.post<{ message: string }>(endpoints.authSendToken, {
+      email,
+      token_type: 'register'
+    })
   }
 
   async verifyEmail(token: string): Promise<LoginResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<LoginResponse>(
-      endpoints.authRegisterVerify,
-      { token }
-    )
+    return this.post<LoginResponse>(endpoints.authRegisterVerify, { token })
   }
 
   async loginWithToken(token: string): Promise<LoginResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<LoginResponse>(
-      endpoints.authLoginToken,
-      { token }
-    )
+    return this.post<LoginResponse>(endpoints.authLoginToken, { token })
   }
 }

--- a/app/composables/api/repositories/CompanyRepository.ts
+++ b/app/composables/api/repositories/CompanyRepository.ts
@@ -1,5 +1,8 @@
 import { BaseRepository } from './BaseRepository'
 import type { Company } from '../../../../shared/types'
+import type {
+  CompanyCreationResponse
+} from '../../../../shared/types/models/Company'
 
 export interface UpdateCompanyRequest {
   name?: string
@@ -11,13 +14,29 @@ export interface UpdateCompanyRequest {
 }
 
 export class CompanyRepository extends BaseRepository {
-  /**
-   * Update company information
-   * PUT /companies/${companyId}
-   * All fields are optional
-   */
-  async updateCompany(companyId: string, data: UpdateCompanyRequest): Promise<Company> {
+  async updateCompany(
+    companyId: string,
+    data: UpdateCompanyRequest
+  ): Promise<Company> {
     const endpoints = useApiEndpoints()
-    return this.put<Company>(`${endpoints.companies}/${companyId}`, data)
+    return this.put<Company>(
+      `${endpoints.companies}/${companyId}`,
+      data
+    )
+  }
+
+  async createCompanyWithSpaces(
+    data: {
+      name: string
+      city: string
+      country: string
+      timezone: string
+    }
+  ): Promise<CompanyCreationResponse> {
+    const endpoints = useApiEndpoints()
+    return this.post<CompanyCreationResponse>(
+      `${endpoints.companies}?create_all_spaces=true`,
+      data
+    )
   }
 }

--- a/app/composables/api/repositories/CompanyRepository.ts
+++ b/app/composables/api/repositories/CompanyRepository.ts
@@ -1,8 +1,6 @@
 import { BaseRepository } from './BaseRepository'
 import type { Company } from '../../../../shared/types'
-import type {
-  CompanyCreationResponse
-} from '../../../../shared/types/models/Company'
+import type { CompanyCreationResponse } from '../../../../shared/types/models/Company'
 
 export interface UpdateCompanyRequest {
   name?: string
@@ -14,29 +12,18 @@ export interface UpdateCompanyRequest {
 }
 
 export class CompanyRepository extends BaseRepository {
-  async updateCompany(
-    companyId: string,
-    data: UpdateCompanyRequest
-  ): Promise<Company> {
+  async updateCompany(companyId: string, data: UpdateCompanyRequest): Promise<Company> {
     const endpoints = useApiEndpoints()
-    return this.put<Company>(
-      `${endpoints.companies}/${companyId}`,
-      data
-    )
+    return this.put<Company>(`${endpoints.companies}/${companyId}`, data)
   }
 
-  async createCompanyWithSpaces(
-    data: {
-      name: string
-      city: string
-      country: string
-      timezone: string
-    }
-  ): Promise<CompanyCreationResponse> {
+  async createCompanyWithSpaces(data: {
+    name: string
+    city: string
+    country: string
+    timezone: string
+  }): Promise<CompanyCreationResponse> {
     const endpoints = useApiEndpoints()
-    return this.post<CompanyCreationResponse>(
-      `${endpoints.companies}?create_all_spaces=true`,
-      data
-    )
+    return this.post<CompanyCreationResponse>(`${endpoints.companies}?create_all_spaces=true`, data)
   }
 }

--- a/app/composables/api/repositories/ContentRepository.ts
+++ b/app/composables/api/repositories/ContentRepository.ts
@@ -1,0 +1,9 @@
+import { BaseRepository } from './BaseRepository'
+import type { ContentPublic } from '../../../../shared/types/api/content.types'
+
+export class ContentRepository extends BaseRepository {
+  async getPublic(): Promise<ContentPublic[]> {
+    const endpoints = useApiEndpoints()
+    return this.get<ContentPublic[]>(endpoints.productsContentPublic)
+  }
+}

--- a/app/composables/api/services/AuthService.ts
+++ b/app/composables/api/services/AuthService.ts
@@ -96,9 +96,14 @@ export class AuthService {
     return response
   }
 
-  /**
-   * Check if user is authenticated
-   */
+  async sendRegisterToken(email: string) {
+    return this.authRepository.sendRegisterToken(email)
+  }
+
+  async resetUserPassword(newPassword: string) {
+    return this.authRepository.resetUserPassword(newPassword)
+  }
+
   get isAuthenticated() {
     return this.authStore.isAuthenticated
   }

--- a/app/composables/useAccount.ts
+++ b/app/composables/useAccount.ts
@@ -102,12 +102,12 @@ export const useAccount = () => {
     }
   }
 
-  const resetPassword = async (currentPassword: string, newPassword: string) => {
+  const resetPassword = async (newPassword: string) => {
     try {
       isLoading.value = true
       error.value = ''
 
-      const response = await authRepository.resetUserPassword(currentPassword, newPassword)
+      const response = await authRepository.resetUserPassword(newPassword)
       return response
     } catch (err: unknown) {
       error.value = err instanceof Error ? err.message : t('errors.account.resetPasswordFailed')

--- a/app/composables/useCompanyInitialization.ts
+++ b/app/composables/useCompanyInitialization.ts
@@ -1,23 +1,17 @@
-import type {
-  CompanyCreationResponse
-} from '../../shared/types/models/Company'
-import {
-  CompanyRepository
-} from './api/repositories/CompanyRepository'
+import type { CompanyCreationResponse } from '../../shared/types/models/Company'
+import { CompanyRepository } from './api/repositories/CompanyRepository'
 import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useCompanyInitialization = () => {
   const authStore = useAuthStore()
   const { handleApiError, handleSilentError } = useErrorHandler()
+  const companyRepository = new CompanyRepository()
 
   const extractNameFromEmail = (email: string): string => {
     const parts = email.split('@')
     const localPart = parts[0] || ''
 
-    const cleanName = localPart
-      .replace(/[._-]/g, ' ')
-      .replace(/\d+/g, '')
-      .trim()
+    const cleanName = localPart.replace(/[._-]/g, ' ').replace(/\d+/g, '').trim()
 
     if (!cleanName) {
       return "User's Farm"
@@ -26,18 +20,13 @@ export const useCompanyInitialization = () => {
     const capitalized = cleanName
       .split(' ')
       .filter(word => word.length > 0)
-      .map(
-        word =>
-          word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-      )
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
       .join(' ')
 
     return capitalized ? `${capitalized}'s Farm` : "User's Farm"
   }
 
-  const createCompanyWithSpaces = async (
-    email: string
-  ): Promise<CompanyCreationResponse> => {
+  const createCompanyWithSpaces = async (email: string): Promise<CompanyCreationResponse> => {
     const companyName = extractNameFromEmail(email)
     const companyData = {
       name: companyName,
@@ -47,26 +36,17 @@ export const useCompanyInitialization = () => {
     }
 
     try {
-      const repository = new CompanyRepository()
-      const response = await repository.createCompanyWithSpaces(
-        companyData
-      )
+      const response = await companyRepository.createCompanyWithSpaces(companyData)
 
       if (import.meta.dev) {
         if (response.failed_space_types?.length) {
-          console.warn(
-            '[CompanyInit] Some spaces failed to create:',
-            response.failed_space_types
-          )
+          console.warn('[CompanyInit] Some spaces failed to create:', response.failed_space_types)
         }
       }
 
       return response
     } catch (error) {
-      const normalizedError = handleApiError(
-        error as Error,
-        'CompanyInit: Create company'
-      )
+      const normalizedError = handleApiError(error as Error, 'CompanyInit: Create company')
       throw normalizedError
     }
   }
@@ -98,16 +78,10 @@ export const useCompanyInitialization = () => {
         return response
       } catch (error) {
         lastError = error as Error
-        handleSilentError(
-          error as Error,
-          `CompanyInit: Attempt ${attempts} failed`
-        )
+        handleSilentError(error as Error, `CompanyInit: Attempt ${attempts} failed`)
 
         if (attempts < maxRetries) {
-          const delay = Math.min(
-            1000 * Math.pow(2, attempts - 1),
-            4000
-          )
+          const delay = Math.min(1000 * Math.pow(2, attempts - 1), 4000)
           if (import.meta.dev) {
             // Waiting before retry
           }
@@ -116,10 +90,7 @@ export const useCompanyInitialization = () => {
       }
     }
 
-    handleSilentError(
-      lastError,
-      'CompanyInit: All attempts failed'
-    )
+    handleSilentError(lastError, 'CompanyInit: All attempts failed')
     return null
   }
 

--- a/app/composables/useCompanyInitialization.ts
+++ b/app/composables/useCompanyInitialization.ts
@@ -1,59 +1,44 @@
-import type { CompanyCreationResponse } from '../../shared/types/models/Company'
+import type {
+  CompanyCreationResponse
+} from '../../shared/types/models/Company'
+import {
+  CompanyRepository
+} from './api/repositories/CompanyRepository'
 import { useErrorHandler } from './errors/useErrorHandler'
 
-/**
- * Composable for handling automatic company initialization after
- * registration
- */
 export const useCompanyInitialization = () => {
-  const { api } = useApi()
-  const endpoints = useApiEndpoints()
   const authStore = useAuthStore()
   const { handleApiError, handleSilentError } = useErrorHandler()
 
-  /**
-   * Extract name from email and format as "[Name]'s Farm"
-   * @param email - User email address
-   * @returns Formatted company name
-   */
   const extractNameFromEmail = (email: string): string => {
-    // Remove domain part
     const parts = email.split('@')
     const localPart = parts[0] || ''
 
-    // Replace common separators with spaces and capitalize
     const cleanName = localPart
       .replace(/[._-]/g, ' ')
-      .replace(/\d+/g, '') // Remove numbers
+      .replace(/\d+/g, '')
       .trim()
 
     if (!cleanName) {
       return "User's Farm"
     }
 
-    // Capitalize each word
     const capitalized = cleanName
       .split(' ')
       .filter(word => word.length > 0)
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .map(
+        word =>
+          word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+      )
       .join(' ')
 
     return capitalized ? `${capitalized}'s Farm` : "User's Farm"
   }
 
-  /**
-   * Create company with all spaces using bulk creation feature
-   * @param token - Authentication token
-   * @param email - User email for generating company name
-   * @returns Company creation response
-   */
   const createCompanyWithSpaces = async (
-    token: string,
     email: string
   ): Promise<CompanyCreationResponse> => {
     const companyName = extractNameFromEmail(email)
-
-    // Default Helsinki location
     const companyData = {
       name: companyName,
       city: 'Helsinki',
@@ -62,40 +47,30 @@ export const useCompanyInitialization = () => {
     }
 
     try {
-      // Create company with all spaces using bulk creation parameter
-      const response = await api<CompanyCreationResponse>(
-        `${endpoints.companies}?create_all_spaces=true`,
-        {
-          method: 'POST',
-          body: companyData,
-          headers: {
-            Authorization: `Bearer ${token}`
-          }
-        }
+      const repository = new CompanyRepository()
+      const response = await repository.createCompanyWithSpaces(
+        companyData
       )
 
       if (import.meta.dev) {
-        // Company created successfully
-
         if (response.failed_space_types?.length) {
-          console.warn('[CompanyInit] Some spaces failed to create:', response.failed_space_types)
+          console.warn(
+            '[CompanyInit] Some spaces failed to create:',
+            response.failed_space_types
+          )
         }
       }
 
       return response
     } catch (error) {
-      // Use the error handler for consistent error handling
-      const normalizedError = handleApiError(error as Error, 'CompanyInit: Create company')
+      const normalizedError = handleApiError(
+        error as Error,
+        'CompanyInit: Create company'
+      )
       throw normalizedError
     }
   }
 
-  /**
-   * Initialize company with retry mechanism
-   * @param email - User email address
-   * @param maxRetries - Maximum number of retry attempts
-   * @returns Company creation response or null if all attempts fail
-   */
   const initializeCompany = async (
     email: string,
     maxRetries = 3
@@ -107,7 +82,6 @@ export const useCompanyInitialization = () => {
       attempts++
 
       try {
-        // Get current token from auth store
         const token = authStore.token
         if (!token) {
           throw new Error('No authentication token available')
@@ -117,20 +91,23 @@ export const useCompanyInitialization = () => {
           // Attempt to create company
         }
 
-        const response = await createCompanyWithSpaces(token as string, email)
+        const response = await createCompanyWithSpaces(email)
 
-        // Success - refresh profile to include new company
         await authStore.fetchProfile()
 
         return response
       } catch (error) {
         lastError = error as Error
-        // Use silent error handler for retry attempts
-        handleSilentError(error as Error, `CompanyInit: Attempt ${attempts} failed`)
+        handleSilentError(
+          error as Error,
+          `CompanyInit: Attempt ${attempts} failed`
+        )
 
         if (attempts < maxRetries) {
-          // Exponential backoff: 1s, 2s, 4s
-          const delay = Math.min(1000 * Math.pow(2, attempts - 1), 4000)
+          const delay = Math.min(
+            1000 * Math.pow(2, attempts - 1),
+            4000
+          )
           if (import.meta.dev) {
             // Waiting before retry
           }
@@ -139,8 +116,10 @@ export const useCompanyInitialization = () => {
       }
     }
 
-    // Log final failure
-    handleSilentError(lastError, 'CompanyInit: All attempts failed')
+    handleSilentError(
+      lastError,
+      'CompanyInit: All attempts failed'
+    )
     return null
   }
 

--- a/app/composables/useContent.ts
+++ b/app/composables/useContent.ts
@@ -8,12 +8,8 @@ export const useContent = () => {
     return contentRepository.getPublic()
   }
 
-  const pickRandomFreeVideo = (
-    videos: ContentPublic[]
-  ): ContentPublic | null => {
-    const freeVideos = videos.filter(
-      v => v.url !== null && v.level === 'basic' && v.credits === 0
-    )
+  const pickRandomFreeVideo = (videos: ContentPublic[]): ContentPublic | null => {
+    const freeVideos = videos.filter(v => v.url !== null && v.level === 'basic' && v.credits === 0)
     if (freeVideos.length === 0) return null
     const idx = Math.floor(Math.random() * freeVideos.length)
     return freeVideos[idx] ?? null

--- a/app/composables/useContent.ts
+++ b/app/composables/useContent.ts
@@ -1,0 +1,26 @@
+import type { ContentPublic } from '../../shared/types/api/content.types'
+import { ContentRepository } from './api/repositories/ContentRepository'
+
+export const useContent = () => {
+  const contentRepository = new ContentRepository()
+
+  const loadPublic = async (): Promise<ContentPublic[]> => {
+    return contentRepository.getPublic()
+  }
+
+  const pickRandomFreeVideo = (
+    videos: ContentPublic[]
+  ): ContentPublic | null => {
+    const freeVideos = videos.filter(
+      v => v.url !== null && v.level === 'basic' && v.credits === 0
+    )
+    if (freeVideos.length === 0) return null
+    const idx = Math.floor(Math.random() * freeVideos.length)
+    return freeVideos[idx] ?? null
+  }
+
+  return {
+    loadPublic,
+    pickRandomFreeVideo
+  }
+}

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -472,9 +472,10 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { ref, onMounted, computed } from 'vue'
-import { AuthService } from '../composables/api/services/AuthService'
+import { AuthService } from '~/composables/api/services/AuthService'
 // Use icons from the centralized useIcons composable
 const { alertCircle, create, warning, wallet } = useIcons()
+const authService = new AuthService()
 
 definePageMeta({
   middleware: 'auth'
@@ -587,10 +588,7 @@ const updatePassword = async () => {
   try {
     passwordLoading.value = true
 
-    const authService = new AuthService()
-    await authService.resetUserPassword(
-      passwordForm.value.newPassword
-    )
+    await authService.resetUserPassword(passwordForm.value.newPassword)
 
     const successToast = await useToast().create({
       message: t('account.password.updateSuccess'),

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -472,6 +472,7 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 import { ref, onMounted, computed } from 'vue'
+import { AuthService } from '../composables/api/services/AuthService'
 // Use icons from the centralized useIcons composable
 const { alertCircle, create, warning, wallet } = useIcons()
 
@@ -586,16 +587,10 @@ const updatePassword = async () => {
   try {
     passwordLoading.value = true
 
-    // Use the API client directly for the new password reset endpoint
-    const { api } = useApi()
-    const endpoints = useApiEndpoints()
-
-    await api(endpoints.usersResetPassword, {
-      method: 'POST',
-      body: {
-        new_password: passwordForm.value.newPassword
-      }
-    })
+    const authService = new AuthService()
+    await authService.resetUserPassword(
+      passwordForm.value.newPassword
+    )
 
     const successToast = await useToast().create({
       message: t('account.password.updateSuccess'),

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -152,7 +152,7 @@ const { t } = useI18n()
 const localePath = useLocalePath()
 const icons = useIcons()
 const authStore = useAuthStore()
-const { api } = useApi()
+const { loadPublic, pickRandomFreeVideo } = useContent()
 
 // Featured video state
 const featuredVideo = ref<ContentPublic | null>(null)
@@ -216,13 +216,8 @@ const swiperConfig = computed<SwiperConfig>(() => {
 // Fetch featured video on mount
 onMounted(async () => {
   try {
-    const videos = await api<ContentPublic[]>('/products/content/public')
-    // Filter for free videos with URLs
-    const freeVideos = videos.filter(v => v.url !== null && v.level === 'basic' && v.credits === 0)
-    if (freeVideos.length > 0) {
-      const idx = Math.floor(Math.random() * freeVideos.length)
-      featuredVideo.value = freeVideos[idx] ?? null
-    }
+    const videos = await loadPublic()
+    featuredVideo.value = pickRandomFreeVideo(videos)
   } catch {
     // Silently fail - no featured video will be shown
   } finally {

--- a/app/pages/tutorials.vue
+++ b/app/pages/tutorials.vue
@@ -180,7 +180,7 @@ definePageMeta({
 })
 
 const { t } = useI18n()
-const { api } = useApi()
+const { loadPublic } = useContent()
 
 // State
 const videos = ref<ContentPublic[]>([])
@@ -275,8 +275,7 @@ const loadVideos = async () => {
   loading.value = true
   error.value = false
   try {
-    const data = await api<ContentPublic[]>('/products/content/public')
-    // Filter only videos with URLs
+    const data = await loadPublic()
     videos.value = data.filter(v => v.url !== null)
   } catch {
     error.value = true

--- a/app/pages/verify-token.vue
+++ b/app/pages/verify-token.vue
@@ -98,7 +98,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { AuthService } from '../composables/api/services/AuthService'
+import { AuthService } from '~/composables/api/services/AuthService'
 
 definePageMeta({
   middleware: 'guest'
@@ -201,9 +201,7 @@ const resendCode = async () => {
 
   try {
     const authService = new AuthService()
-    await authService.sendRegisterToken(
-      registrationEmail as string
-    )
+    await authService.sendRegisterToken(registrationEmail as string)
 
     // Show success message or toast
     // TODO: Add toast notification

--- a/app/pages/verify-token.vue
+++ b/app/pages/verify-token.vue
@@ -98,6 +98,7 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
+import { AuthService } from '../composables/api/services/AuthService'
 
 definePageMeta({
   middleware: 'guest'
@@ -199,17 +200,10 @@ const resendCode = async () => {
   resending.value = true
 
   try {
-    // Send new verification token
-    const { api } = useApi()
-    const endpoints = useApiEndpoints()
-
-    await api(endpoints.authSendToken, {
-      method: 'POST',
-      body: {
-        email: registrationEmail,
-        token_type: 'register'
-      }
-    })
+    const authService = new AuthService()
+    await authService.sendRegisterToken(
+      registrationEmail as string
+    )
 
     // Show success message or toast
     // TODO: Add toast notification

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -161,6 +161,8 @@ export default defineNuxtConfig({
         authResetPassword: '/auth/reset-password',
         authResetPasswordConfirm: '/auth/reset-password/confirm',
         authSendToken: '/auth/send-token',
+        authLogout: '/auth/logout',
+        authRefresh: '/auth/refresh',
 
         // Legacy endpoints (still available)
         login: '/login',
@@ -195,6 +197,7 @@ export default defineNuxtConfig({
         metricsExcel: '/metrics/excel',
         // Products (Learning Content)
         productsContent: '/products/content',
+        productsContentPublic: '/products/content/public',
         productsPlaylists: '/products/playlists',
         productsTools: '/products/tools',
         productsPurchase: '/products/purchase',

--- a/tests/unit/api/repositories/AuthRepository.test.ts
+++ b/tests/unit/api/repositories/AuthRepository.test.ts
@@ -11,15 +11,15 @@ const mockAuthStore = createMockAuthStore()
 global.useAuthStore = vi.fn(() => mockAuthStore)
 
 global.useApiEndpoints = vi.fn(() => ({
-  authSendToken: '/auth/send-token',
-  authRefresh: '/auth/refresh',
-  authLogin: '/auth/login',
-  authRegister: '/auth/register',
-  authResetPassword: '/auth/reset-password',
-  authResetPasswordConfirm: '/auth/reset-password/confirm',
-  authRegisterVerify: '/auth/register/verify',
-  authLoginToken: '/auth/login/token',
-  usersResetPassword: '/users/reset_password'
+  authSendToken: '/__test__/auth/send-token',
+  authRefresh: '/__test__/auth/refresh',
+  authLogin: '/__test__/auth/login',
+  authRegister: '/__test__/auth/register',
+  authResetPassword: '/__test__/auth/reset-password',
+  authResetPasswordConfirm: '/__test__/auth/reset-password/confirm',
+  authRegisterVerify: '/__test__/auth/register/verify',
+  authLoginToken: '/__test__/auth/login/token',
+  usersResetPassword: '/__test__/users/reset_password'
 }))
 
 global.useRuntimeConfig = vi.fn(() => ({
@@ -40,26 +40,24 @@ describe('AuthRepository', () => {
 
   describe('sendRegisterToken', () => {
     it('should POST to authSendToken endpoint with email and token_type', async () => {
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue({ message: 'Token sent' })
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue({
+        message: 'Token sent'
+      })
 
       const email = 'test@example.com'
       await repository.sendRegisterToken(email)
 
-      expect(repository.post).toHaveBeenCalledWith(
-        '/auth/send-token',
-        { email, token_type: 'register' }
-      )
+      expect(repository.post).toHaveBeenCalledWith('/__test__/auth/send-token', {
+        email,
+        token_type: 'register'
+      })
     })
 
     it('should return success response', async () => {
       const mockResponse = { message: 'Token sent' }
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.sendRegisterToken('test@example.com')
       expect(result).toEqual(mockResponse)
@@ -70,14 +68,9 @@ describe('AuthRepository', () => {
         statusCode: 400,
         data: { message: 'Invalid email' }
       }
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockRejectedValue(error)
 
-      await expect(
-        repository.sendRegisterToken('bad-email')
-      ).rejects.toMatchObject(error)
+      await expect(repository.sendRegisterToken('bad-email')).rejects.toMatchObject(error)
     })
   })
 
@@ -91,17 +84,13 @@ describe('AuthRepository', () => {
         token_type: 'bearer'
       }
 
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue(
+        mockResponse
+      )
 
       await repository.refreshToken(refreshData)
 
-      expect(repository.post).toHaveBeenCalledWith(
-        '/auth/refresh',
-        refreshData
-      )
+      expect(repository.post).toHaveBeenCalledWith('/__test__/auth/refresh', refreshData)
     })
 
     it('should return refresh token response', async () => {
@@ -114,10 +103,9 @@ describe('AuthRepository', () => {
         expires_in: 3600
       }
 
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.refreshToken(refreshData)
       expect(result).toEqual(mockResponse)
@@ -126,39 +114,34 @@ describe('AuthRepository', () => {
 
   describe('resetUserPassword', () => {
     it('should POST with only new_password (no current_password)', async () => {
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue({ message: 'Password reset' })
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue({
+        message: 'Password reset'
+      })
 
       const newPassword = 'newSecurePassword123'
       await repository.resetUserPassword(newPassword)
 
-      expect(repository.post).toHaveBeenCalledWith(
-        '/users/reset_password',
-        { new_password: newPassword }
-      )
+      expect(repository.post).toHaveBeenCalledWith('/__test__/users/reset_password', {
+        new_password: newPassword
+      })
     })
 
     it('should use usersResetPassword endpoint', async () => {
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue({ message: 'Password reset' })
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue({
+        message: 'Password reset'
+      })
 
       await repository.resetUserPassword('newPass123')
 
-      const callArgs = (repository.post as ReturnType<typeof vi.fn>)
-        .mock.calls[0]
-      expect(callArgs[0]).toBe('/users/reset_password')
+      const callArgs = (repository.post as ReturnType<typeof vi.fn>).mock.calls[0]
+      expect(callArgs[0]).toBe('/__test__/users/reset_password')
     })
 
     it('should return success response', async () => {
       const mockResponse = { message: 'Password updated' }
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.resetUserPassword('newPass')
       expect(result).toEqual(mockResponse)

--- a/tests/unit/api/repositories/AuthRepository.test.ts
+++ b/tests/unit/api/repositories/AuthRepository.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { AuthRepository } from '~/composables/api/repositories/AuthRepository'
+import type { RefreshTokenRequest } from '../../../../shared/types'
+
+const createMockAuthStore = () => ({
+  token: null as string | null,
+  isAuthenticated: false
+})
+
+const mockAuthStore = createMockAuthStore()
+global.useAuthStore = vi.fn(() => mockAuthStore)
+
+global.useApiEndpoints = vi.fn(() => ({
+  authSendToken: '/auth/send-token',
+  authRefresh: '/auth/refresh',
+  authLogin: '/auth/login',
+  authRegister: '/auth/register',
+  authResetPassword: '/auth/reset-password',
+  authResetPasswordConfirm: '/auth/reset-password/confirm',
+  authRegisterVerify: '/auth/register/verify',
+  authLoginToken: '/auth/login/token',
+  usersResetPassword: '/users/reset_password'
+}))
+
+global.useRuntimeConfig = vi.fn(() => ({
+  public: { domainAlias: 'bsfapp' }
+}))
+
+describe('AuthRepository', () => {
+  let repository: AuthRepository
+
+  beforeEach(() => {
+    mockAuthStore.token = 'test-token'
+    mockAuthStore.isAuthenticated = true
+    repository = new AuthRepository()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('sendRegisterToken', () => {
+    it('should POST to authSendToken endpoint with email and token_type', async () => {
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue({ message: 'Token sent' })
+
+      const email = 'test@example.com'
+      await repository.sendRegisterToken(email)
+
+      expect(repository.post).toHaveBeenCalledWith(
+        '/auth/send-token',
+        { email, token_type: 'register' }
+      )
+    })
+
+    it('should return success response', async () => {
+      const mockResponse = { message: 'Token sent' }
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue(mockResponse)
+
+      const result = await repository.sendRegisterToken('test@example.com')
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should handle API errors', async () => {
+      const error = {
+        statusCode: 400,
+        data: { message: 'Invalid email' }
+      }
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockRejectedValue(error)
+
+      await expect(
+        repository.sendRegisterToken('bad-email')
+      ).rejects.toMatchObject(error)
+    })
+  })
+
+  describe('refreshToken', () => {
+    it('should POST to authRefresh endpoint (not hardcoded)', async () => {
+      const refreshData: RefreshTokenRequest = {
+        refresh_token: 'refresh-token-123'
+      }
+      const mockResponse = {
+        access_token: 'new-token',
+        token_type: 'bearer'
+      }
+
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue(mockResponse)
+
+      await repository.refreshToken(refreshData)
+
+      expect(repository.post).toHaveBeenCalledWith(
+        '/auth/refresh',
+        refreshData
+      )
+    })
+
+    it('should return refresh token response', async () => {
+      const refreshData: RefreshTokenRequest = {
+        refresh_token: 'refresh-token-123'
+      }
+      const mockResponse = {
+        access_token: 'new-token',
+        token_type: 'bearer',
+        expires_in: 3600
+      }
+
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue(mockResponse)
+
+      const result = await repository.refreshToken(refreshData)
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('resetUserPassword', () => {
+    it('should POST with only new_password (no current_password)', async () => {
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue({ message: 'Password reset' })
+
+      const newPassword = 'newSecurePassword123'
+      await repository.resetUserPassword(newPassword)
+
+      expect(repository.post).toHaveBeenCalledWith(
+        '/users/reset_password',
+        { new_password: newPassword }
+      )
+    })
+
+    it('should use usersResetPassword endpoint', async () => {
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue({ message: 'Password reset' })
+
+      await repository.resetUserPassword('newPass123')
+
+      const callArgs = (repository.post as ReturnType<typeof vi.fn>)
+        .mock.calls[0]
+      expect(callArgs[0]).toBe('/users/reset_password')
+    })
+
+    it('should return success response', async () => {
+      const mockResponse = { message: 'Password updated' }
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue(mockResponse)
+
+      const result = await repository.resetUserPassword('newPass')
+      expect(result).toEqual(mockResponse)
+    })
+  })
+})

--- a/tests/unit/api/repositories/CompanyRepository.test.ts
+++ b/tests/unit/api/repositories/CompanyRepository.test.ts
@@ -15,6 +15,13 @@ global.useApiEndpoints = vi.fn(() => ({
   companies: '/api/v1/companies'
 }))
 
+interface CreateCompanyData {
+  name: string
+  city: string
+  country: string
+  timezone: string
+}
+
 describe('CompanyRepository', () => {
   let repository: CompanyRepository
 
@@ -213,6 +220,82 @@ describe('CompanyRepository', () => {
 
       expect(result).toHaveProperty('_id', companyId)
       expect(result.name).toBe('MongoDB Company')
+    })
+  })
+
+  describe('createCompanyWithSpaces', () => {
+    it('should POST to companies endpoint with create_all_spaces query', async () => {
+      const data: CreateCompanyData = {
+        name: "Test User's Farm",
+        city: 'Helsinki',
+        country: 'FI',
+        timezone: 'Europe/Helsinki'
+      }
+
+      const mockResponse = {
+        status: 'success',
+        company_id: 'new-company-id',
+        created_spaces: ['space1', 'space2']
+      }
+
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue(mockResponse)
+
+      const result = await repository.createCompanyWithSpaces(data)
+
+      expect(result).toEqual(mockResponse)
+      expect(repository.post).toHaveBeenCalledWith(
+        '/api/v1/companies?create_all_spaces=true',
+        data
+      )
+    })
+
+    it('should accept only a data object (no token parameter)', async () => {
+      const data: CreateCompanyData = {
+        name: "Another Farm",
+        city: 'Tampere',
+        country: 'FI',
+        timezone: 'Europe/Helsinki'
+      }
+
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockResolvedValue({ status: 'success' })
+
+      await repository.createCompanyWithSpaces(data)
+
+      // Verify post was called with exactly 2 args: url and data
+      const callArgs = (
+        repository.post as ReturnType<typeof vi.fn>
+      ).mock.calls[0]
+      expect(callArgs).toHaveLength(2)
+      expect(callArgs[1]).toEqual(data)
+    })
+
+    it('should handle API errors', async () => {
+      const data: CreateCompanyData = {
+        name: 'Fail Farm',
+        city: 'Helsinki',
+        country: 'FI',
+        timezone: 'Europe/Helsinki'
+      }
+
+      const error = {
+        statusCode: 500,
+        data: { message: 'Server error' }
+      }
+
+      vi.spyOn(
+        repository as unknown as { post: () => unknown },
+        'post'
+      ).mockRejectedValue(error)
+
+      await expect(
+        repository.createCompanyWithSpaces(data)
+      ).rejects.toMatchObject(error)
     })
   })
 })

--- a/tests/unit/api/repositories/CompanyRepository.test.ts
+++ b/tests/unit/api/repositories/CompanyRepository.test.ts
@@ -238,39 +238,33 @@ describe('CompanyRepository', () => {
         created_spaces: ['space1', 'space2']
       }
 
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue(mockResponse)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue(
+        mockResponse
+      )
 
       const result = await repository.createCompanyWithSpaces(data)
 
       expect(result).toEqual(mockResponse)
-      expect(repository.post).toHaveBeenCalledWith(
-        '/api/v1/companies?create_all_spaces=true',
-        data
-      )
+      expect(repository.post).toHaveBeenCalledWith('/api/v1/companies?create_all_spaces=true', data)
     })
 
     it('should accept only a data object (no token parameter)', async () => {
       const data: CreateCompanyData = {
-        name: "Another Farm",
+        name: 'Another Farm',
         city: 'Tampere',
         country: 'FI',
         timezone: 'Europe/Helsinki'
       }
 
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockResolvedValue({ status: 'success' })
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockResolvedValue({
+        status: 'success',
+        company_id: 'test-company-id'
+      })
 
       await repository.createCompanyWithSpaces(data)
 
       // Verify post was called with exactly 2 args: url and data
-      const callArgs = (
-        repository.post as ReturnType<typeof vi.fn>
-      ).mock.calls[0]
+      const callArgs = (repository.post as ReturnType<typeof vi.fn>).mock.calls[0]
       expect(callArgs).toHaveLength(2)
       expect(callArgs[1]).toEqual(data)
     })
@@ -288,14 +282,9 @@ describe('CompanyRepository', () => {
         data: { message: 'Server error' }
       }
 
-      vi.spyOn(
-        repository as unknown as { post: () => unknown },
-        'post'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { post: () => unknown }, 'post').mockRejectedValue(error)
 
-      await expect(
-        repository.createCompanyWithSpaces(data)
-      ).rejects.toMatchObject(error)
+      await expect(repository.createCompanyWithSpaces(data)).rejects.toMatchObject(error)
     })
   })
 })

--- a/tests/unit/api/repositories/ContentRepository.test.ts
+++ b/tests/unit/api/repositories/ContentRepository.test.ts
@@ -11,24 +11,26 @@ const mockAuthStore = createMockAuthStore()
 global.useAuthStore = vi.fn(() => mockAuthStore)
 
 global.useApiEndpoints = vi.fn(() => ({
-  productsContentPublic: '/products/content/public'
+  productsContentPublic: '/__test__/products/content/public'
 }))
 
-const mockContent: ContentPublic[] = [{
-  _id: '1',
-  title: 'Test Video',
-  description: 'A test',
-  category: 'video',
-  level: 'basic',
-  credits: 0,
-  profile_tags: ['newbie'],
-  category_tags: ['breeding'],
-  url: 'https://example.com/video.mp4',
-  active: true,
-  expiry_days: 30,
-  created_at: '2024-01-01T00:00:00Z',
-  available_at: '2024-01-01T00:00:00Z'
-}]
+const mockContent: ContentPublic[] = [
+  {
+    _id: '1',
+    title: 'Test Video',
+    description: 'A test',
+    category: 'video',
+    level: 'basic',
+    credits: 0,
+    profile_tags: ['newbie'],
+    category_tags: ['breeding'],
+    url: 'https://example.com/video.mp4',
+    active: true,
+    expiry_days: 30,
+    created_at: '2024-01-01T00:00:00Z',
+    available_at: '2024-01-01T00:00:00Z'
+  }
+]
 
 describe('ContentRepository', () => {
   let repository: ContentRepository
@@ -44,24 +46,20 @@ describe('ContentRepository', () => {
 
   describe('getPublic', () => {
     it('should fetch public content', async () => {
-      vi.spyOn(
-        repository as unknown as { get: () => unknown },
-        'get'
-      ).mockResolvedValue(mockContent)
+      vi.spyOn(repository as unknown as { get: () => unknown }, 'get').mockResolvedValue(
+        mockContent
+      )
 
       const result = await repository.getPublic()
 
       expect(result).toEqual(mockContent)
-      expect(repository.get).toHaveBeenCalledWith(
-        '/products/content/public'
-      )
+      expect(repository.get).toHaveBeenCalledWith('/__test__/products/content/public')
     })
 
     it('should return typed ContentPublic array', async () => {
-      vi.spyOn(
-        repository as unknown as { get: () => unknown },
-        'get'
-      ).mockResolvedValue(mockContent)
+      vi.spyOn(repository as unknown as { get: () => unknown }, 'get').mockResolvedValue(
+        mockContent
+      )
 
       const result: ContentPublic[] = await repository.getPublic()
 
@@ -77,10 +75,7 @@ describe('ContentRepository', () => {
         data: { message: 'Internal server error' }
       }
 
-      vi.spyOn(
-        repository as unknown as { get: () => unknown },
-        'get'
-      ).mockRejectedValue(error)
+      vi.spyOn(repository as unknown as { get: () => unknown }, 'get').mockRejectedValue(error)
 
       await expect(repository.getPublic()).rejects.toMatchObject(error)
     })

--- a/tests/unit/api/repositories/ContentRepository.test.ts
+++ b/tests/unit/api/repositories/ContentRepository.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ContentRepository } from '~/composables/api/repositories/ContentRepository'
+import type { ContentPublic } from '../../../../shared/types'
+
+const createMockAuthStore = () => ({
+  token: null as string | null,
+  isAuthenticated: false
+})
+
+const mockAuthStore = createMockAuthStore()
+global.useAuthStore = vi.fn(() => mockAuthStore)
+
+global.useApiEndpoints = vi.fn(() => ({
+  productsContentPublic: '/products/content/public'
+}))
+
+const mockContent: ContentPublic[] = [{
+  _id: '1',
+  title: 'Test Video',
+  description: 'A test',
+  category: 'video',
+  level: 'basic',
+  credits: 0,
+  profile_tags: ['newbie'],
+  category_tags: ['breeding'],
+  url: 'https://example.com/video.mp4',
+  active: true,
+  expiry_days: 30,
+  created_at: '2024-01-01T00:00:00Z',
+  available_at: '2024-01-01T00:00:00Z'
+}]
+
+describe('ContentRepository', () => {
+  let repository: ContentRepository
+
+  beforeEach(() => {
+    mockAuthStore.token = 'test-token'
+    mockAuthStore.isAuthenticated = true
+    repository = new ContentRepository()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  describe('getPublic', () => {
+    it('should fetch public content', async () => {
+      vi.spyOn(
+        repository as unknown as { get: () => unknown },
+        'get'
+      ).mockResolvedValue(mockContent)
+
+      const result = await repository.getPublic()
+
+      expect(result).toEqual(mockContent)
+      expect(repository.get).toHaveBeenCalledWith(
+        '/products/content/public'
+      )
+    })
+
+    it('should return typed ContentPublic array', async () => {
+      vi.spyOn(
+        repository as unknown as { get: () => unknown },
+        'get'
+      ).mockResolvedValue(mockContent)
+
+      const result: ContentPublic[] = await repository.getPublic()
+
+      expect(Array.isArray(result)).toBe(true)
+      expect(result[0]).toHaveProperty('_id')
+      expect(result[0]).toHaveProperty('title')
+      expect(result[0]).toHaveProperty('category')
+    })
+
+    it('should handle API errors', async () => {
+      const error = {
+        statusCode: 500,
+        data: { message: 'Internal server error' }
+      }
+
+      vi.spyOn(
+        repository as unknown as { get: () => unknown },
+        'get'
+      ).mockRejectedValue(error)
+
+      await expect(repository.getPublic()).rejects.toMatchObject(error)
+    })
+  })
+})

--- a/tests/unit/composables/api/services/AuthService.test.ts
+++ b/tests/unit/composables/api/services/AuthService.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { AuthService } from '~/composables/api/services/AuthService'
+
+const createMockAuthStore = () => ({
+  token: 'test-token' as string | null,
+  isAuthenticated: true,
+  user: null,
+  setToken: vi.fn(),
+  fetchProfile: vi.fn(),
+  logout: vi.fn()
+})
+
+const mockAuthStore = createMockAuthStore()
+global.useAuthStore = vi.fn(() => mockAuthStore)
+
+global.useApiEndpoints = vi.fn(() => ({
+  authSendToken: '/auth/send-token',
+  authRefresh: '/auth/refresh',
+  authLogin: '/auth/login',
+  authRegister: '/auth/register',
+  authResetPassword: '/auth/reset-password',
+  authResetPasswordConfirm: '/auth/reset-password/confirm',
+  authRegisterVerify: '/auth/register/verify',
+  authLoginToken: '/auth/login/token',
+  usersResetPassword: '/users/reset_password'
+}))
+
+global.useRuntimeConfig = vi.fn(() => ({
+  public: { domainAlias: 'bsfapp' }
+}))
+
+// Mock AuthRepository prototype methods
+const mockSendRegisterToken = vi.fn()
+const mockResetUserPassword = vi.fn()
+
+vi.mock('~/composables/api/repositories/AuthRepository', () => ({
+  AuthRepository: vi.fn().mockImplementation(() => ({
+    sendRegisterToken: mockSendRegisterToken,
+    resetUserPassword: mockResetUserPassword,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    refreshToken: vi.fn(),
+    sendPasswordReset: vi.fn(),
+    confirmPasswordReset: vi.fn(),
+    verifyEmail: vi.fn(),
+    loginWithToken: vi.fn()
+  }))
+}))
+
+describe('AuthService', () => {
+  let service: AuthService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new AuthService()
+  })
+
+  describe('sendRegisterToken', () => {
+    it('should delegate to AuthRepository.sendRegisterToken', async () => {
+      const email = 'test@example.com'
+      const mockResponse = { message: 'Token sent' }
+      mockSendRegisterToken.mockResolvedValue(mockResponse)
+
+      const result = await service.sendRegisterToken(email)
+
+      expect(mockSendRegisterToken).toHaveBeenCalledWith(email)
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should pass email argument through unchanged', async () => {
+      const email = 'another@test.com'
+      mockSendRegisterToken.mockResolvedValue({ message: 'ok' })
+
+      await service.sendRegisterToken(email)
+
+      expect(mockSendRegisterToken).toHaveBeenCalledTimes(1)
+      expect(mockSendRegisterToken).toHaveBeenCalledWith(email)
+    })
+  })
+
+  describe('resetUserPassword', () => {
+    it('should delegate to AuthRepository.resetUserPassword', async () => {
+      const newPassword = 'securePassword123'
+      const mockResponse = { message: 'Password reset' }
+      mockResetUserPassword.mockResolvedValue(mockResponse)
+
+      const result = await service.resetUserPassword(newPassword)
+
+      expect(mockResetUserPassword).toHaveBeenCalledWith(newPassword)
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should pass only newPassword argument', async () => {
+      mockResetUserPassword.mockResolvedValue({ message: 'ok' })
+
+      await service.resetUserPassword('newPass')
+
+      expect(mockResetUserPassword).toHaveBeenCalledTimes(1)
+      expect(mockResetUserPassword).toHaveBeenCalledWith('newPass')
+    })
+  })
+})

--- a/tests/unit/composables/api/services/AuthService.test.ts
+++ b/tests/unit/composables/api/services/AuthService.test.ts
@@ -174,7 +174,7 @@ describe('AuthService', () => {
       mockVerifyEmail.mockResolvedValue(response)
       const mockStorage = { set: vi.fn(), get: vi.fn() }
       const origUseStorage = global.useStorage
-      global.useStorage = vi.fn(() => mockStorage) as any
+      global.useStorage = vi.fn(() => mockStorage) as unknown as typeof global.useStorage
 
       const result = await service.verifyEmail('email-token')
 

--- a/tests/unit/composables/api/services/AuthService.test.ts
+++ b/tests/unit/composables/api/services/AuthService.test.ts
@@ -32,20 +32,32 @@ global.useRuntimeConfig = vi.fn(() => ({
 // Mock AuthRepository prototype methods
 const mockSendRegisterToken = vi.fn()
 const mockResetUserPassword = vi.fn()
+const mockLogin = vi.fn()
+const mockRegister = vi.fn()
+const mockSendPasswordReset = vi.fn()
+const mockVerifyEmail = vi.fn()
+const mockLoginWithToken = vi.fn()
 
 vi.mock('~/composables/api/repositories/AuthRepository', () => ({
   AuthRepository: vi.fn().mockImplementation(() => ({
     sendRegisterToken: mockSendRegisterToken,
     resetUserPassword: mockResetUserPassword,
-    login: vi.fn(),
-    register: vi.fn(),
+    login: mockLogin,
+    register: mockRegister,
     logout: vi.fn(),
     refreshToken: vi.fn(),
-    sendPasswordReset: vi.fn(),
+    sendPasswordReset: mockSendPasswordReset,
     confirmPasswordReset: vi.fn(),
-    verifyEmail: vi.fn(),
-    loginWithToken: vi.fn()
+    verifyEmail: mockVerifyEmail,
+    loginWithToken: mockLoginWithToken
   }))
+}))
+
+// Mock useMetrics dynamic import used in loginWithToken
+vi.mock('../../useMetrics', () => ({
+  useMetrics: () => ({
+    trackLogin: vi.fn()
+  })
 }))
 
 describe('AuthService', () => {
@@ -98,6 +110,116 @@ describe('AuthService', () => {
 
       expect(mockResetUserPassword).toHaveBeenCalledTimes(1)
       expect(mockResetUserPassword).toHaveBeenCalledWith('newPass')
+    })
+  })
+
+  describe('login', () => {
+    it('should call repo, set token, and fetch profile', async () => {
+      const credentials = { email: 'a@b.com', password: 'pw' }
+      const response = { access_token: 'tok123', token_type: 'bearer' }
+      mockLogin.mockResolvedValue(response)
+
+      const result = await service.login(credentials)
+
+      expect(mockLogin).toHaveBeenCalledWith(credentials)
+      expect(mockAuthStore.setToken).toHaveBeenCalledWith('tok123')
+      expect(mockAuthStore.fetchProfile).toHaveBeenCalled()
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('register', () => {
+    it('should delegate to AuthRepository.register', async () => {
+      const userData = {
+        email: 'new@user.com',
+        password: 'pass123'
+      }
+      const response = { status: 'ok', message: 'registered' }
+      mockRegister.mockResolvedValue(response)
+
+      const result = await service.register(userData)
+
+      expect(mockRegister).toHaveBeenCalledWith(userData)
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('logout', () => {
+    it('should clear auth state and navigate to /', async () => {
+      await service.logout()
+
+      expect(mockAuthStore.logout).toHaveBeenCalled()
+      expect(navigateTo).toHaveBeenCalledWith('/')
+    })
+  })
+
+  describe('sendPasswordReset', () => {
+    it('should delegate to AuthRepository.sendPasswordReset', async () => {
+      const mockResponse = { message: 'Email sent' }
+      mockSendPasswordReset.mockResolvedValue(mockResponse)
+
+      const result = await service.sendPasswordReset('a@b.com')
+
+      expect(mockSendPasswordReset).toHaveBeenCalledWith('a@b.com')
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('verifyEmail', () => {
+    it('should verify, set token, flag storage, fetch profile', async () => {
+      const response = {
+        access_token: 'verified-tok',
+        token_type: 'bearer'
+      }
+      mockVerifyEmail.mockResolvedValue(response)
+      const mockStorage = { set: vi.fn(), get: vi.fn() }
+      const origUseStorage = global.useStorage
+      global.useStorage = vi.fn(() => mockStorage) as any
+
+      const result = await service.verifyEmail('email-token')
+
+      expect(mockVerifyEmail).toHaveBeenCalledWith('email-token')
+      expect(mockAuthStore.setToken).toHaveBeenCalledWith('verified-tok')
+      expect(mockStorage.set).toHaveBeenCalledWith('needs_company_init', true)
+      expect(mockAuthStore.fetchProfile).toHaveBeenCalled()
+      expect(result).toEqual(response)
+
+      global.useStorage = origUseStorage
+    })
+  })
+
+  describe('loginWithToken', () => {
+    it('should login with token, set token, fetch profile', async () => {
+      const response = {
+        access_token: 'token-login-tok',
+        token_type: 'bearer'
+      }
+      mockLoginWithToken.mockResolvedValue(response)
+
+      const result = await service.loginWithToken('magic-token')
+
+      expect(mockLoginWithToken).toHaveBeenCalledWith('magic-token')
+      expect(mockAuthStore.setToken).toHaveBeenCalledWith('token-login-tok')
+      expect(mockAuthStore.fetchProfile).toHaveBeenCalled()
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('isAuthenticated', () => {
+    it('should return authStore.isAuthenticated', () => {
+      expect(service.isAuthenticated).toBe(true)
+    })
+  })
+
+  describe('currentUser', () => {
+    it('should return authStore.user', () => {
+      expect(service.currentUser).toBeNull()
+    })
+  })
+
+  describe('token', () => {
+    it('should return authStore.token', () => {
+      expect(service.token).toBe('test-token')
     })
   })
 })

--- a/tests/unit/composables/useCompanyInitialization.test.ts
+++ b/tests/unit/composables/useCompanyInitialization.test.ts
@@ -1,19 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useCompanyInitialization } from '~/composables/useCompanyInitialization'
 
+const mockCreateCompanyWithSpaces = vi.fn()
+
+vi.mock('~/composables/api/repositories/CompanyRepository', () => ({
+  CompanyRepository: vi.fn().mockImplementation(() => ({
+    createCompanyWithSpaces: mockCreateCompanyWithSpaces
+  }))
+}))
+
 describe('useCompanyInitialization', () => {
   let companyInit: ReturnType<typeof useCompanyInitialization>
-  let mockApi: ReturnType<typeof vi.fn>
   let mockFetchProfile: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
-    // Reset mocks before each test
-    mockApi = vi.fn()
     mockFetchProfile = vi.fn()
 
-    // Override global mocks for this test suite
-    vi.stubGlobal('useApi', () => ({ api: mockApi }))
-    vi.stubGlobal('useApiEndpoints', () => ({ companies: '/companies' }))
     vi.stubGlobal('useAuthStore', () => ({
       token: 'mock-token',
       fetchProfile: mockFetchProfile
@@ -67,32 +69,31 @@ describe('useCompanyInitialization', () => {
 
     it('should handle edge cases gracefully', () => {
       expect(companyInit.extractNameFromEmail('')).toBe("User's Farm")
-      expect(companyInit.extractNameFromEmail('invalid')).toBe("Invalid's Farm")
+      expect(
+        companyInit.extractNameFromEmail('invalid')
+      ).toBe("Invalid's Farm")
       expect(companyInit.extractNameFromEmail('@')).toBe("User's Farm")
     })
   })
 
   describe('createCompanyWithSpaces', () => {
-    it('should create company with correct data', async () => {
-      mockApi.mockResolvedValue({
+    it('should delegate to CompanyRepository with data object', async () => {
+      mockCreateCompanyWithSpaces.mockResolvedValue({
         status: 'success',
         company_id: 'test-company-id',
         created_spaces: ['space1', 'space2', 'space3']
       })
 
-      const result = await companyInit.createCompanyWithSpaces('test-token', 'test.user@email.com')
+      const result = await companyInit.createCompanyWithSpaces(
+        'test.user@email.com'
+      )
 
-      expect(mockApi).toHaveBeenCalledWith('/companies?create_all_spaces=true', {
-        method: 'POST',
-        body: {
-          name: "Test User's Farm",
-          city: 'Helsinki',
-          country: 'FI',
-          timezone: 'Europe/Helsinki'
-        },
-        headers: {
-          Authorization: 'Bearer test-token'
-        }
+      // New signature: only data, no token
+      expect(mockCreateCompanyWithSpaces).toHaveBeenCalledWith({
+        name: "Test User's Farm",
+        city: 'Helsinki',
+        country: 'FI',
+        timezone: 'Europe/Helsinki'
       })
 
       expect(result).toEqual({
@@ -102,11 +103,26 @@ describe('useCompanyInitialization', () => {
       })
     })
 
+    it('should not pass token as a parameter', async () => {
+      mockCreateCompanyWithSpaces.mockResolvedValue({
+        status: 'success'
+      })
+
+      await companyInit.createCompanyWithSpaces('test@email.com')
+
+      // createCompanyWithSpaces on repo takes only data, no token
+      const callArgs = mockCreateCompanyWithSpaces.mock.calls[0]
+      expect(callArgs).toHaveLength(1)
+      expect(callArgs[0]).not.toHaveProperty('token')
+    })
+
     it('should handle API errors', async () => {
-      mockApi.mockRejectedValue(new Error('API Error'))
+      mockCreateCompanyWithSpaces.mockRejectedValue(
+        new Error('API Error')
+      )
 
       await expect(
-        companyInit.createCompanyWithSpaces('test-token', 'test@email.com')
+        companyInit.createCompanyWithSpaces('test@email.com')
       ).rejects.toThrow('API Error')
     })
   })
@@ -121,23 +137,25 @@ describe('useCompanyInitialization', () => {
     })
 
     it('should succeed on first attempt', async () => {
-      mockApi.mockResolvedValue({
+      mockCreateCompanyWithSpaces.mockResolvedValue({
         status: 'success',
         company_id: 'test-company-id'
       })
 
-      const result = await companyInit.initializeCompany('test@email.com')
+      const result = await companyInit.initializeCompany(
+        'test@email.com'
+      )
 
       expect(result).toEqual({
         status: 'success',
         company_id: 'test-company-id'
       })
-      expect(mockApi).toHaveBeenCalledTimes(1)
+      expect(mockCreateCompanyWithSpaces).toHaveBeenCalledTimes(1)
       expect(mockFetchProfile).toHaveBeenCalledTimes(1)
     })
 
     it('should retry on failure with exponential backoff', async () => {
-      mockApi
+      mockCreateCompanyWithSpaces
         .mockRejectedValueOnce(new Error('First attempt failed'))
         .mockRejectedValueOnce(new Error('Second attempt failed'))
         .mockResolvedValue({
@@ -145,11 +163,13 @@ describe('useCompanyInitialization', () => {
           company_id: 'test-company-id'
         })
 
-      const promise = companyInit.initializeCompany('test@email.com', 3)
+      const promise = companyInit.initializeCompany(
+        'test@email.com', 3
+      )
 
       // Fast-forward through delays
-      await vi.advanceTimersByTimeAsync(1000) // First retry delay
-      await vi.advanceTimersByTimeAsync(2000) // Second retry delay
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(2000)
 
       const result = await promise
 
@@ -157,34 +177,37 @@ describe('useCompanyInitialization', () => {
         status: 'success',
         company_id: 'test-company-id'
       })
-      expect(mockApi).toHaveBeenCalledTimes(3)
+      expect(mockCreateCompanyWithSpaces).toHaveBeenCalledTimes(3)
     })
 
     it('should return null after max retries', async () => {
-      mockApi.mockRejectedValue(new Error('API Error'))
+      mockCreateCompanyWithSpaces.mockRejectedValue(
+        new Error('API Error')
+      )
 
-      const promise = companyInit.initializeCompany('test@email.com', 2)
+      const promise = companyInit.initializeCompany(
+        'test@email.com', 2
+      )
 
-      // Fast-forward through delays
-      await vi.advanceTimersByTimeAsync(1000) // First retry delay
+      await vi.advanceTimersByTimeAsync(1000)
 
       const result = await promise
 
       expect(result).toBeNull()
-      expect(mockApi).toHaveBeenCalledTimes(2)
+      expect(mockCreateCompanyWithSpaces).toHaveBeenCalledTimes(2)
     })
 
     it('should handle missing token gracefully', async () => {
-      // Override the auth store mock with null token
       vi.stubGlobal('useAuthStore', () => ({
         token: null,
         fetchProfile: vi.fn()
       }))
 
-      // Re-initialize the composable with the new mock
       companyInit = useCompanyInitialization()
 
-      const result = await companyInit.initializeCompany('test@email.com', 1)
+      const result = await companyInit.initializeCompany(
+        'test@email.com', 1
+      )
 
       expect(result).toBeNull()
     })

--- a/tests/unit/composables/useCompanyInitialization.test.ts
+++ b/tests/unit/composables/useCompanyInitialization.test.ts
@@ -69,9 +69,7 @@ describe('useCompanyInitialization', () => {
 
     it('should handle edge cases gracefully', () => {
       expect(companyInit.extractNameFromEmail('')).toBe("User's Farm")
-      expect(
-        companyInit.extractNameFromEmail('invalid')
-      ).toBe("Invalid's Farm")
+      expect(companyInit.extractNameFromEmail('invalid')).toBe("Invalid's Farm")
       expect(companyInit.extractNameFromEmail('@')).toBe("User's Farm")
     })
   })
@@ -84,9 +82,7 @@ describe('useCompanyInitialization', () => {
         created_spaces: ['space1', 'space2', 'space3']
       })
 
-      const result = await companyInit.createCompanyWithSpaces(
-        'test.user@email.com'
-      )
+      const result = await companyInit.createCompanyWithSpaces('test.user@email.com')
 
       // New signature: only data, no token
       expect(mockCreateCompanyWithSpaces).toHaveBeenCalledWith({
@@ -117,13 +113,11 @@ describe('useCompanyInitialization', () => {
     })
 
     it('should handle API errors', async () => {
-      mockCreateCompanyWithSpaces.mockRejectedValue(
-        new Error('API Error')
-      )
+      mockCreateCompanyWithSpaces.mockRejectedValue(new Error('API Error'))
 
-      await expect(
-        companyInit.createCompanyWithSpaces('test@email.com')
-      ).rejects.toThrow('API Error')
+      await expect(companyInit.createCompanyWithSpaces('test@email.com')).rejects.toThrow(
+        'API Error'
+      )
     })
   })
 
@@ -142,9 +136,7 @@ describe('useCompanyInitialization', () => {
         company_id: 'test-company-id'
       })
 
-      const result = await companyInit.initializeCompany(
-        'test@email.com'
-      )
+      const result = await companyInit.initializeCompany('test@email.com')
 
       expect(result).toEqual({
         status: 'success',
@@ -163,9 +155,7 @@ describe('useCompanyInitialization', () => {
           company_id: 'test-company-id'
         })
 
-      const promise = companyInit.initializeCompany(
-        'test@email.com', 3
-      )
+      const promise = companyInit.initializeCompany('test@email.com', 3)
 
       // Fast-forward through delays
       await vi.advanceTimersByTimeAsync(1000)
@@ -181,13 +171,9 @@ describe('useCompanyInitialization', () => {
     })
 
     it('should return null after max retries', async () => {
-      mockCreateCompanyWithSpaces.mockRejectedValue(
-        new Error('API Error')
-      )
+      mockCreateCompanyWithSpaces.mockRejectedValue(new Error('API Error'))
 
-      const promise = companyInit.initializeCompany(
-        'test@email.com', 2
-      )
+      const promise = companyInit.initializeCompany('test@email.com', 2)
 
       await vi.advanceTimersByTimeAsync(1000)
 
@@ -205,9 +191,7 @@ describe('useCompanyInitialization', () => {
 
       companyInit = useCompanyInitialization()
 
-      const result = await companyInit.initializeCompany(
-        'test@email.com', 1
-      )
+      const result = await companyInit.initializeCompany('test@email.com', 1)
 
       expect(result).toBeNull()
     })

--- a/tests/unit/composables/useContent.test.ts
+++ b/tests/unit/composables/useContent.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ContentPublic } from '../../../shared/types/api/content.types'
+import {
+  freeVideoWithQueryParams,
+  premiumVideo,
+  directVimeoUrlWithWww,
+  directVimeoUrlNoWww,
+  freeVideoNoQueryParams,
+  videoWithManyQueryParams
+} from '../../fixtures/videos'
+
+const mockGetPublic = vi.fn()
+
+vi.mock('~/composables/api/repositories/ContentRepository', () => ({
+  ContentRepository: vi.fn().mockImplementation(() => ({
+    getPublic: mockGetPublic
+  }))
+}))
+
+import { useContent } from '../../../app/composables/useContent'
+
+describe('useContent', () => {
+  let content: ReturnType<typeof useContent>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    content = useContent()
+  })
+
+  describe('loadPublic', () => {
+    it('should delegate to ContentRepository.getPublic', async () => {
+      const videos = [freeVideoWithQueryParams, premiumVideo]
+      mockGetPublic.mockResolvedValue(videos)
+
+      const result = await content.loadPublic()
+
+      expect(mockGetPublic).toHaveBeenCalledOnce()
+      expect(result).toEqual(videos)
+    })
+
+    it('should return empty array when no content', async () => {
+      mockGetPublic.mockResolvedValue([])
+
+      const result = await content.loadPublic()
+
+      expect(result).toEqual([])
+    })
+
+    it('should propagate errors from repository', async () => {
+      const error = new Error('Network error')
+      mockGetPublic.mockRejectedValue(error)
+
+      await expect(content.loadPublic()).rejects.toThrow('Network error')
+    })
+  })
+
+  describe('pickRandomFreeVideo', () => {
+    it('should return null for empty array', () => {
+      const result = content.pickRandomFreeVideo([])
+      expect(result).toBeNull()
+    })
+
+    it('should filter out videos with null url', () => {
+      // premiumVideo has url: null, level: 'advanced', credits: 10
+      // Create a video that is basic + 0 credits but null url
+      const nullUrlBasic: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'null-url',
+        url: null
+      }
+      const result = content.pickRandomFreeVideo([nullUrlBasic])
+      expect(result).toBeNull()
+    })
+
+    it('should filter out non-basic level videos', () => {
+      // freeVideoNoQueryParams has level: 'intermediate'
+      const result = content.pickRandomFreeVideo([freeVideoNoQueryParams])
+      expect(result).toBeNull()
+    })
+
+    it('should filter out videos with credits > 0', () => {
+      // directVimeoUrlNoWww has level: 'intermediate', credits: 5
+      // Create a basic video with credits > 0
+      const paidBasic: ContentPublic = {
+        ...freeVideoWithQueryParams,
+        _id: 'paid-basic',
+        credits: 5
+      }
+      const result = content.pickRandomFreeVideo([paidBasic])
+      expect(result).toBeNull()
+    })
+
+    it('should return a matching free basic video', () => {
+      // freeVideoWithQueryParams: url set, level: 'basic', credits: 0
+      const result = content.pickRandomFreeVideo([freeVideoWithQueryParams])
+      expect(result).toEqual(freeVideoWithQueryParams)
+    })
+
+    it('should only return videos matching all criteria', () => {
+      const videos = [
+        premiumVideo, // url: null, advanced, credits: 10
+        freeVideoNoQueryParams, // intermediate, credits: 0
+        freeVideoWithQueryParams // basic, credits: 0, url set
+      ]
+      // Run multiple times to ensure only valid video returned
+      for (let i = 0; i < 20; i++) {
+        const result = content.pickRandomFreeVideo(videos)
+        expect(result).toEqual(freeVideoWithQueryParams)
+      }
+    })
+
+    it('should use Math.random for selection', () => {
+      const eligible = [
+        freeVideoWithQueryParams, // basic, 0 credits, url set
+        directVimeoUrlWithWww, // basic, 0 credits, url set
+        videoWithManyQueryParams // basic, 0 credits, url set
+      ]
+
+      // Force Math.random to return 0 -> index 0
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      expect(content.pickRandomFreeVideo(eligible)).toEqual(freeVideoWithQueryParams)
+
+      // Force Math.random to return 0.99 -> last index
+      vi.spyOn(Math, 'random').mockReturnValue(0.99)
+      expect(content.pickRandomFreeVideo(eligible)).toEqual(videoWithManyQueryParams)
+
+      vi.restoreAllMocks()
+    })
+
+    it('should return null when all videos are filtered out', () => {
+      const videos = [
+        premiumVideo, // url: null, advanced, credits: 10
+        freeVideoNoQueryParams, // intermediate
+        directVimeoUrlNoWww // intermediate, credits: 5
+      ]
+      const result = content.pickRandomFreeVideo(videos)
+      expect(result).toBeNull()
+    })
+  })
+})

--- a/tests/unit/composables/useContent.test.ts
+++ b/tests/unit/composables/useContent.test.ts
@@ -17,6 +17,7 @@ vi.mock('~/composables/api/repositories/ContentRepository', () => ({
   }))
 }))
 
+// eslint-disable-next-line import/first
 import { useContent } from '../../../app/composables/useContent'
 
 describe('useContent', () => {

--- a/tests/unit/pages/index.test.ts
+++ b/tests/unit/pages/index.test.ts
@@ -23,7 +23,18 @@ vi.stubGlobal('definePageMeta', vi.fn())
 // eslint-disable-next-line import/first
 import IndexPage from '~/pages/index.vue'
 
-const apiMock = vi.fn()
+const loadPublicMock = vi.fn()
+
+/**
+ * Real pickRandomFreeVideo logic so tests can
+ * verify filtering behavior end-to-end.
+ */
+const pickRandomFreeVideo = (videos: ContentPublic[]): ContentPublic | null => {
+  const freeVideos = videos.filter(v => v.url !== null && v.level === 'basic' && v.credits === 0)
+  if (freeVideos.length === 0) return null
+  const idx = Math.floor(Math.random() * freeVideos.length)
+  return freeVideos[idx] ?? null
+}
 
 const stubs = {
   VideoCard: {
@@ -46,9 +57,12 @@ function mountPage(
 ) {
   const { authenticated = false, apiResult = [] } = overrides
 
-  apiMock.mockResolvedValue(apiResult)
+  loadPublicMock.mockResolvedValue(apiResult)
 
-  vi.stubGlobal('useApi', () => ({ api: apiMock }))
+  vi.stubGlobal('useContent', () => ({
+    loadPublic: loadPublicMock,
+    pickRandomFreeVideo
+  }))
   vi.stubGlobal('useAuthStore', () =>
     reactive({
       user: null,
@@ -72,7 +86,7 @@ describe('IndexPage', () => {
   let randomSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    apiMock.mockReset()
+    loadPublicMock.mockReset()
     randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0)
   })
 
@@ -85,7 +99,7 @@ describe('IndexPage', () => {
       mountPage({ apiResult: [] })
       await flushPromises()
 
-      expect(apiMock).toHaveBeenCalledWith('/products/content/public')
+      expect(loadPublicMock).toHaveBeenCalled()
     })
 
     it('filters out videos with null url', async () => {
@@ -180,8 +194,11 @@ describe('IndexPage', () => {
     it('hides featured section while loading', () => {
       // Do not await flushPromises so
       // loadingVideo stays true
-      apiMock.mockReturnValue(new Promise(() => {}))
-      vi.stubGlobal('useApi', () => ({ api: apiMock }))
+      loadPublicMock.mockReturnValue(new Promise(() => {}))
+      vi.stubGlobal('useContent', () => ({
+        loadPublic: loadPublicMock,
+        pickRandomFreeVideo
+      }))
       vi.stubGlobal('useAuthStore', () =>
         reactive({
           user: null,
@@ -207,8 +224,11 @@ describe('IndexPage', () => {
 
   describe('Error Handling', () => {
     it('does not show error UI on API failure', async () => {
-      apiMock.mockRejectedValue(new Error('Network error'))
-      vi.stubGlobal('useApi', () => ({ api: apiMock }))
+      loadPublicMock.mockRejectedValue(new Error('Network error'))
+      vi.stubGlobal('useContent', () => ({
+        loadPublic: loadPublicMock,
+        pickRandomFreeVideo
+      }))
       vi.stubGlobal('useAuthStore', () =>
         reactive({
           user: null,
@@ -233,8 +253,11 @@ describe('IndexPage', () => {
     })
 
     it('hides featured section on API error', async () => {
-      apiMock.mockRejectedValue(new Error('Server error'))
-      vi.stubGlobal('useApi', () => ({ api: apiMock }))
+      loadPublicMock.mockRejectedValue(new Error('Server error'))
+      vi.stubGlobal('useContent', () => ({
+        loadPublic: loadPublicMock,
+        pickRandomFreeVideo
+      }))
       vi.stubGlobal('useAuthStore', () =>
         reactive({
           user: null,

--- a/tests/unit/pages/tutorials.test.ts
+++ b/tests/unit/pages/tutorials.test.ts
@@ -56,17 +56,19 @@ async function mountPage(
   } = {}
 ): Promise<{
   wrapper: VueWrapper
-  mockApi: ReturnType<typeof vi.fn>
+  loadPublicMock: ReturnType<typeof vi.fn>
 }> {
-  const mockApi = vi.fn()
+  const loadPublicMock = vi.fn()
 
   if (opts.apiError) {
-    mockApi.mockRejectedValueOnce(new Error('Network error'))
+    loadPublicMock.mockRejectedValueOnce(new Error('Network error'))
   } else {
-    mockApi.mockResolvedValueOnce(opts.apiResponse ?? allVideos)
+    loadPublicMock.mockResolvedValueOnce(opts.apiResponse ?? allVideos)
   }
 
-  vi.stubGlobal('useApi', () => ({ api: mockApi }))
+  vi.stubGlobal('useContent', () => ({
+    loadPublic: loadPublicMock
+  }))
 
   const wrapper = mount(TutorialsPage, {
     global: {
@@ -94,7 +96,7 @@ async function mountPage(
     await flushPromises()
   }
 
-  return { wrapper, mockApi }
+  return { wrapper, loadPublicMock }
 }
 
 describe('TutorialsPage', () => {
@@ -107,9 +109,9 @@ describe('TutorialsPage', () => {
   // 1. API Integration
   // -----------------------------------------------
   describe('API Integration', () => {
-    it('calls API on mount with correct endpoint', async () => {
-      const { mockApi } = await mountPage()
-      expect(mockApi).toHaveBeenCalledWith('/products/content/public')
+    it('calls loadPublic on mount', async () => {
+      const { loadPublicMock } = await mountPage()
+      expect(loadPublicMock).toHaveBeenCalled()
     })
 
     it('shows loading state before API resolves', async () => {
@@ -120,19 +122,19 @@ describe('TutorialsPage', () => {
     })
 
     it('shows error state on API failure with retry', async () => {
-      const { wrapper, mockApi } = await mountPage({
+      const { wrapper, loadPublicMock } = await mountPage({
         apiError: true
       })
 
       expect(wrapper.find('.error-stub').exists()).toBe(true)
 
       // Setup a successful retry
-      mockApi.mockResolvedValueOnce(allVideos)
+      loadPublicMock.mockResolvedValueOnce(allVideos)
       await wrapper.find('.retry').trigger('click')
       await flushPromises()
 
       expect(wrapper.find('.error-stub').exists()).toBe(false)
-      expect(mockApi).toHaveBeenCalledTimes(2)
+      expect(loadPublicMock).toHaveBeenCalledTimes(2)
     })
   })
 


### PR DESCRIPTION
## Summary

- Create `ContentRepository` + `useContent` composable to replace direct `useApi()` calls in `index.vue` and `tutorials.vue`
- Add `CompanyRepository.createCompanyWithSpaces` and migrate `useCompanyInitialization` to use it (removes explicit `Authorization` header, uses `BaseRepository` plumbing)
- Add `AuthRepository.sendRegisterToken` + `AuthService` passthroughs; migrate `verify-token.vue` and `account.vue` away from inline API calls
- Externalize 3 hardcoded endpoint paths (`authLogout`, `authRefresh`, `productsContentPublic`) into `nuxt.config.ts`
- Delete dead `AuthRepository.logout()` method (intentional divergence from golden — `AuthService.logout()` is client-only by design)
- Simplify `resetUserPassword` from `(currentPassword, newPassword)` to `(newPassword)` — `currentPassword` was never supplied by callers

## Acceptance criteria verified

- `grep -rn "useApi()" app/pages app/composables` → only `BaseRepository.ts` ✅
- `grep -rn "'/auth/\|'/products/content/public'" app/composables/api` → zero ✅
- All 86 targeted Vitest specs pass ✅
- `npm run typecheck` clean ✅
- `npm run generate` (SSG) succeeds ✅

## Test plan

- [x] 86 unit tests passing (ContentRepository, AuthRepository, CompanyRepository, AuthService, useCompanyInitialization, BaseRepository)
- [ ] CI checks pass (lint, format, typecheck, full test suite)
- [ ] Manual: Load `/` — featured video block appears
- [ ] Manual: Load `/tutorials` — video grid loads, filters respond
- [ ] Manual: Register → verify-token → resend button works
- [ ] Manual: `/account` → reset password → success toast

Closes #23

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public content composable for fetching content and selecting a random featured video
  * Send registration verification token by email
  * Company creation that initializes associated spaces

* **Bug Fixes**
  * Password reset no longer requires the current password

* **Refactor**
  * Authentication flows routed through a service layer; pages use the new content composable and auth service

* **Tests**
  * New unit tests covering auth, company, content, and related pages/composables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->