### PR TITLE
refactor: centralize error handling via useErrorHandler

### DIFF
--- a/app/components/help/HelpIcon.vue
+++ b/app/components/help/HelpIcon.vue
@@ -18,6 +18,7 @@ import { useI18n } from 'vue-i18n'
 import type { HelpTopic } from '../../../shared/types/help'
 import { useHelp } from '~/composables/useHelp'
 import { useIcons } from '~/composables/useIcons'
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
 interface Props {
   /**
@@ -59,6 +60,7 @@ const props = withDefaults(defineProps<Props>(), {
 const { t } = useI18n()
 const { showHelp } = useHelp()
 const { helpCircleOutline } = useIcons()
+const { handleSilentError } = useErrorHandler()
 
 const translate = (key: string, fallback: string, params?: Record<string, unknown>): string => {
   const translated = params ? t(key, params) : t(key)
@@ -111,10 +113,9 @@ const handleClick = async (event: Event) => {
   event.stopPropagation()
 
   try {
-    console.log(`[HelpIcon] Showing help for topic: ${props.topic ?? ''}`)
     await showHelp(props.topic)
   } catch (error) {
-    console.error('[HelpIcon] Failed to show help:', error)
+    handleSilentError(error, 'HelpIcon.showHelp')
   }
 }
 </script>

--- a/app/components/help/HelpModal.vue
+++ b/app/components/help/HelpModal.vue
@@ -79,6 +79,7 @@ import { useI18n } from 'vue-i18n'
 import type { HelpContent } from '../../../shared/types/help'
 import { HelpTopic, isValidHelpTopic } from '../../../shared/types/help'
 import { useIcons } from '~/composables/useIcons'
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
 interface Props {
   topic?: HelpTopic | null
@@ -90,6 +91,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { t } = useI18n()
 const { close, helpCircleOutline } = useIcons()
+const { handleSilentError } = useErrorHandler()
 
 const closeIcon = close
 const helpIcon = helpCircleOutline
@@ -139,7 +141,10 @@ const helpContent: ComputedRef<HelpContent | null> = computed(() => {
   const currentTopic = props.topic || selectedTopic.value
 
   if (!isValidHelpTopic(currentTopic)) {
-    console.warn(`[HelpModal] Invalid topic: ${currentTopic}`)
+    handleSilentError(
+      new Error('Invalid topic: ' + currentTopic),
+      'HelpModal.loadContent'
+    )
     return null
   }
 
@@ -204,7 +209,7 @@ const dismiss = async () => {
   try {
     await modalController.dismiss()
   } catch (error) {
-    console.error('[HelpModal] Error dismissing:', error)
+    handleSilentError(error, 'HelpModal.dismiss')
   }
 }
 
@@ -212,8 +217,6 @@ const dismiss = async () => {
 const scrollToTopic = () => {
   if (props.topic) {
     selectedTopic.value = props.topic
-    // Could implement actual scrolling here if needed
-    console.log(`[HelpModal] Scrolled to topic: ${props.topic}`)
   }
 }
 

--- a/app/components/help/HelpModal.vue
+++ b/app/components/help/HelpModal.vue
@@ -141,10 +141,7 @@ const helpContent: ComputedRef<HelpContent | null> = computed(() => {
   const currentTopic = props.topic || selectedTopic.value
 
   if (!isValidHelpTopic(currentTopic)) {
-    handleSilentError(
-      new Error('Invalid topic: ' + currentTopic),
-      'HelpModal.loadContent'
-    )
+    handleSilentError(new Error('Invalid topic: ' + currentTopic), 'HelpModal.loadContent')
     return null
   }
 

--- a/app/components/layout/PrivateFooter.vue
+++ b/app/components/layout/PrivateFooter.vue
@@ -48,10 +48,7 @@ const toggleMenu = async () => {
     }
 
     if (!menuController) {
-      handleSilentError(
-        new Error('Menu controller not available'),
-        'PrivateFooter.toggleMenu'
-      )
+      handleSilentError(new Error('Menu controller not available'), 'PrivateFooter.toggleMenu')
       return
     }
 

--- a/app/components/layout/PrivateFooter.vue
+++ b/app/components/layout/PrivateFooter.vue
@@ -29,8 +29,10 @@
 <script setup lang="ts">
 import { menuController } from '@ionic/vue'
 import { useI18n } from 'vue-i18n'
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
 const { t } = useI18n()
+const { handleSilentError } = useErrorHandler()
 const { menu, home } = useIcons()
 const localePath = useLocalePath()
 
@@ -46,9 +48,10 @@ const toggleMenu = async () => {
     }
 
     if (!menuController) {
-      if (import.meta.dev) {
-        console.warn('Menu controller not available')
-      }
+      handleSilentError(
+        new Error('Menu controller not available'),
+        'PrivateFooter.toggleMenu'
+      )
       return
     }
 
@@ -61,9 +64,7 @@ const toggleMenu = async () => {
       }
     }
   } catch (error) {
-    if (import.meta.dev) {
-      console.warn('Menu toggle failed', error)
-    }
+    handleSilentError(error, 'PrivateFooter.toggleMenu')
   }
 }
 </script>

--- a/app/components/ui/feedback/ErrorBoundary.vue
+++ b/app/components/ui/feedback/ErrorBoundary.vue
@@ -97,8 +97,9 @@ const handleRetry = () => {
   emit('retry')
 }
 
+const localePath = useLocalePath()
 const goHome = () => {
-  navigateTo('/')
+  navigateTo(localePath('/'))
 }
 
 // Allow programmatic error triggering

--- a/app/components/ui/feedback/ErrorBoundary.vue
+++ b/app/components/ui/feedback/ErrorBoundary.vue
@@ -81,7 +81,9 @@ onErrorCaptured((error: Error, _instance, errorInfo) => {
 
   // Log error in development
   if (import.meta.dev) {
+    // eslint-disable-next-line no-console -- prevent recursion with handleError
     console.error(t('errors.boundary.caughtLog'), error)
+    // eslint-disable-next-line no-console -- prevent recursion with handleError
     console.error(t('errors.boundary.infoLog'), errorInfo)
   }
 

--- a/app/composables/api/services/LogService.ts
+++ b/app/composables/api/services/LogService.ts
@@ -59,10 +59,7 @@ export class LogService {
     logType: string,
     content: Record<string, unknown>
   ): Promise<CreateLogResponse> {
-    // Validate log type
-    if (!this.isValidLogType(logType)) {
-      console.warn(`Non-standard log type used: ${logType}`)
-    }
+    // Validate log type (non-standard types are allowed)
 
     const log = this.createLogEntry(logType, content)
     return this.logRepository.createProcessLog(log, { space_id: spaceId })

--- a/app/composables/api/services/MetricsService.ts
+++ b/app/composables/api/services/MetricsService.ts
@@ -20,8 +20,6 @@ export class MetricsService {
 
       return await this.metricsRepository.sendMetric(data)
     } catch (error) {
-      // Log but don't throw for metrics - they should never break the app
-      console.error('MetricsService error:', error)
       return {
         success: false,
         message: error instanceof Error ? error.message : 'Unknown error'

--- a/app/composables/api/utils/errorHandler.ts
+++ b/app/composables/api/utils/errorHandler.ts
@@ -37,6 +37,7 @@ export function handleApiError(
   const formattedError = `Failed to ${context}: ${errorMessage}`
 
   if (logError) {
+    // eslint-disable-next-line no-console -- transport layer, no Vue context
     console.error(formattedError, error)
   }
 

--- a/app/composables/errors/useErrorHandler.ts
+++ b/app/composables/errors/useErrorHandler.ts
@@ -88,6 +88,7 @@ export function useErrorHandler() {
 
     // Log to console in development
     if (logToConsole && import.meta.dev) {
+      // eslint-disable-next-line no-console -- dev diagnostic fallback
       console.error(
         `[${normalizedError.source.toUpperCase()}] Error${source ? ` in ${source}` : ''}:`,
         normalizedError
@@ -95,7 +96,7 @@ export function useErrorHandler() {
     }
 
     // Show user-friendly message
-    if (showToast) {
+    if (showToast && import.meta.client) {
       toast
         .create({
           message: normalizedError.message,

--- a/app/composables/examples/useLogExample.ts
+++ b/app/composables/examples/useLogExample.ts
@@ -5,6 +5,7 @@
 
 import { LogType } from '../../../shared/types/models/log'
 import { useLog } from '../useLog'
+import { useErrorHandler } from '../errors/useErrorHandler'
 
 /**
  * Example: Logging user activities
@@ -65,6 +66,7 @@ export const useActivityLogger = () => {
  */
 export const useProcessLogger = () => {
   const { postLog } = useLog()
+  const { handleError } = useErrorHandler()
 
   /**
    * Log a task completion
@@ -88,7 +90,7 @@ export const useProcessLogger = () => {
       // Task logged successfully
       return response
     } catch (error) {
-      console.error('Failed to log task:', error)
+      handleError(error, { source: 'useLogExample.logTask' })
       throw error
     }
   }

--- a/app/composables/useAccount.ts
+++ b/app/composables/useAccount.ts
@@ -8,7 +8,7 @@ import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useAccount = () => {
   const { t } = useI18n()
-  const { handleError } = useErrorHandler()
+  const { handleError, handleSilentError } = useErrorHandler()
   // State
   const user = ref<User | null>(null)
   const creditHistory = ref<Credit[]>([])
@@ -79,7 +79,7 @@ export const useAccount = () => {
       creditHistory.value = response.data || []
     } catch (err: unknown) {
       // Log the error but don't fail silently - credits should be available
-      handleError(err, { source: 'useAccount.loadCreditHistory' })
+      handleSilentError(err, 'useAccount.loadCreditHistory')
       creditHistory.value = []
       // Don't throw error to prevent blocking the account page
     }

--- a/app/composables/useAccount.ts
+++ b/app/composables/useAccount.ts
@@ -4,9 +4,11 @@ import type { User, UpdateUserRequest, Credit } from '../../shared/types'
 import { UserRepository } from './api/repositories/UserRepository'
 import { CreditRepository } from './api/repositories/CreditRepository'
 import { AuthRepository } from './api/repositories/AuthRepository'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useAccount = () => {
   const { t } = useI18n()
+  const { handleError } = useErrorHandler()
   // State
   const user = ref<User | null>(null)
   const creditHistory = ref<Credit[]>([])
@@ -35,7 +37,7 @@ export const useAccount = () => {
       user.value = authStore.user ? JSON.parse(JSON.stringify(authStore.user)) : null
     } catch (err: unknown) {
       error.value = err instanceof Error ? err.message : t('errors.account.loadProfileFailed')
-      console.error(t('errors.account.loadProfileLog'), err)
+      handleError(err, { source: 'useAccount.loadProfile' })
     } finally {
       isLoading.value = false
     }
@@ -58,7 +60,7 @@ export const useAccount = () => {
       return response
     } catch (err: unknown) {
       error.value = err instanceof Error ? err.message : t('errors.account.updateProfileFailed')
-      console.error(t('errors.account.updateProfileLog'), err)
+      handleError(err, { source: 'useAccount.updateProfile' })
       throw err
     } finally {
       isLoading.value = false
@@ -77,7 +79,7 @@ export const useAccount = () => {
       creditHistory.value = response.data || []
     } catch (err: unknown) {
       // Log the error but don't fail silently - credits should be available
-      console.error(t('errors.account.creditHistoryLog'), err)
+      handleError(err, { source: 'useAccount.loadCreditHistory' })
       creditHistory.value = []
       // Don't throw error to prevent blocking the account page
     }
@@ -95,7 +97,7 @@ export const useAccount = () => {
       return response
     } catch (err: unknown) {
       error.value = err instanceof Error ? err.message : t('errors.account.sendResetFailed')
-      console.error(t('errors.account.sendResetLog'), err)
+      handleError(err, { source: 'useAccount.sendPasswordReset' })
       throw err
     } finally {
       isLoading.value = false
@@ -111,7 +113,7 @@ export const useAccount = () => {
       return response
     } catch (err: unknown) {
       error.value = err instanceof Error ? err.message : t('errors.account.resetPasswordFailed')
-      console.error(t('errors.account.resetPasswordLog'), err)
+      handleError(err, { source: 'useAccount.resetPassword' })
       throw err
     } finally {
       isLoading.value = false

--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -1,6 +1,8 @@
 import { API_TIMEOUT } from '~/utils/constants'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useApi = () => {
+  const { handleError } = useErrorHandler()
   const config = useRuntimeConfig()
 
   const api = $fetch.create({
@@ -42,8 +44,7 @@ export const useApi = () => {
       }
     },
     onRequestError({ error }) {
-      // Handle network errors like ECONNRESET
-      console.error('Network error:', error)
+      handleError(error, { source: 'useApi.request' })
       throw createError({
         statusCode: 500,
         statusMessage: 'Network connection error. Please check your internet connection.'

--- a/app/composables/useApi.ts
+++ b/app/composables/useApi.ts
@@ -2,7 +2,7 @@ import { API_TIMEOUT } from '~/utils/constants'
 import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useApi = () => {
-  const { handleError } = useErrorHandler()
+  const { handleSilentError } = useErrorHandler()
   const config = useRuntimeConfig()
 
   const api = $fetch.create({
@@ -44,7 +44,7 @@ export const useApi = () => {
       }
     },
     onRequestError({ error }) {
-      handleError(error, { source: 'useApi.request' })
+      handleSilentError(error, 'useApi.request')
       throw createError({
         statusCode: 500,
         statusMessage: 'Network connection error. Please check your internet connection.'

--- a/app/composables/useCompanyEdit.ts
+++ b/app/composables/useCompanyEdit.ts
@@ -14,7 +14,7 @@ export const useCompanyEdit = () => {
   const { isCompanyAdmin, isCompanyManager } = useUserRole()
   const companyRepository = new CompanyRepository()
   const toast = useToast()
-  const { handleError } = useErrorHandler()
+  const { handleSilentError } = useErrorHandler()
 
   const companyEditSchema = createCompanyEditSchema(t)
 
@@ -154,7 +154,7 @@ export const useCompanyEdit = () => {
 
       isEditing.value = false
     } catch (err: unknown) {
-      handleError(err, { source: 'useCompanyEdit.updateCompany' })
+      handleSilentError(err, 'useCompanyEdit.updateCompany')
       error.value = err instanceof Error ? err.message : t('account.company.updateError')
 
       await toast.showError(error.value || t('common.error'))

--- a/app/composables/useCompanyEdit.ts
+++ b/app/composables/useCompanyEdit.ts
@@ -5,6 +5,7 @@ import { createCompanyEditSchema } from '~/utils/validation/companySchemas'
 import type { CompanyEditForm } from '~/utils/validation/companySchemas'
 import { CompanyRepository } from './api/repositories/CompanyRepository'
 import type { UpdateCompanyRequest } from './api/repositories/CompanyRepository'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useCompanyEdit = () => {
   const { activeCompany } = useProfile()
@@ -13,6 +14,7 @@ export const useCompanyEdit = () => {
   const { isCompanyAdmin, isCompanyManager } = useUserRole()
   const companyRepository = new CompanyRepository()
   const toast = useToast()
+  const { handleError } = useErrorHandler()
 
   const companyEditSchema = createCompanyEditSchema(t)
 
@@ -152,7 +154,7 @@ export const useCompanyEdit = () => {
 
       isEditing.value = false
     } catch (err: unknown) {
-      console.error(t('errors.account.updateCompanyLog'), err)
+      handleError(err, { source: 'useCompanyEdit.updateCompany' })
       error.value = err instanceof Error ? err.message : t('account.company.updateError')
 
       await toast.showError(error.value || t('common.error'))

--- a/app/composables/useCompanyInitialization.ts
+++ b/app/composables/useCompanyInitialization.ts
@@ -40,10 +40,7 @@ export const useCompanyInitialization = () => {
 
       if (response.failed_space_types?.length) {
         handleSilentError(
-          new Error(
-            'Some spaces failed to create: '
-              + JSON.stringify(response.failed_space_types)
-          ),
+          new Error('Some spaces failed to create: ' + JSON.stringify(response.failed_space_types)),
           'useCompanyInitialization.initialize'
         )
       }

--- a/app/composables/useCompanyInitialization.ts
+++ b/app/composables/useCompanyInitialization.ts
@@ -38,10 +38,14 @@ export const useCompanyInitialization = () => {
     try {
       const response = await companyRepository.createCompanyWithSpaces(companyData)
 
-      if (import.meta.dev) {
-        if (response.failed_space_types?.length) {
-          console.warn('[CompanyInit] Some spaces failed to create:', response.failed_space_types)
-        }
+      if (response.failed_space_types?.length) {
+        handleSilentError(
+          new Error(
+            'Some spaces failed to create: '
+              + JSON.stringify(response.failed_space_types)
+          ),
+          'useCompanyInitialization.initialize'
+        )
       }
 
       return response

--- a/app/composables/useCurrencyExchange.ts
+++ b/app/composables/useCurrencyExchange.ts
@@ -115,6 +115,7 @@ export const useCurrencyExchange = () => {
   }
 
   const saveToCache = (currency: string, rate: number) => {
+    if (!import.meta.client) return
     try {
       const cacheStr = localStorage.getItem(CACHE_KEY)
       const cache: ExchangeRateCache = cacheStr ? JSON.parse(cacheStr) : {}

--- a/app/composables/useCurrencyExchange.ts
+++ b/app/composables/useCurrencyExchange.ts
@@ -1,3 +1,5 @@
+import { useErrorHandler } from './errors/useErrorHandler'
+
 interface ExchangeRateCache {
   [currency: string]: {
     rate: number
@@ -13,6 +15,7 @@ const API_TIMEOUT = 5000 // 5 seconds
 const pendingRequests = new Map<string, Promise<number | null>>()
 
 export const useCurrencyExchange = () => {
+  const { handleSilentError } = useErrorHandler()
   const config = useRuntimeConfig()
 
   const getUSDRate = async (currency: string): Promise<number | null> => {
@@ -84,8 +87,7 @@ export const useCurrencyExchange = () => {
 
       return null
     } catch (error) {
-      // Silent failure - return null
-      console.warn(`Currency conversion failed for ${currency}:`, error)
+      handleSilentError(error, 'useCurrencyExchange.convert')
       return null
     }
   }
@@ -124,7 +126,7 @@ export const useCurrencyExchange = () => {
 
       localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
     } catch (error) {
-      console.warn('Failed to save exchange rate to cache:', error)
+      handleSilentError(error, 'useCurrencyExchange.cacheRate')
     }
   }
 

--- a/app/composables/useHelp.ts
+++ b/app/composables/useHelp.ts
@@ -5,6 +5,7 @@ import { ref, onUnmounted, getCurrentInstance } from 'vue'
 import type { HelpTopic } from '../../shared/types/help'
 import { isValidHelpTopic } from '../../shared/types/help'
 import HelpModal from '~/components/help/HelpModal.vue'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 // Singleton modal instance reference with stronger typing
 let currentModal: HTMLIonModalElement | null = null
@@ -20,6 +21,7 @@ let previousActiveElement: HTMLElement | null = null
 
 export const useHelp = () => {
   const { t } = useI18n()
+  const { handleSilentError } = useErrorHandler()
 
   const translate = (key: string, fallback: string, params?: Record<string, unknown>): string => {
     const translated = params ? t(key, params) : t(key)
@@ -40,17 +42,14 @@ export const useHelp = () => {
    */
   const validateTopic = (topic?: HelpTopic): HelpTopic | null => {
     if (!topic) {
-      console.debug('[useHelp] No topic provided')
       return null
     }
 
     if (typeof topic !== 'string') {
-      console.warn('[useHelp] Invalid help topic type:', typeof topic)
       return null
     }
 
     if (!isValidHelpTopic(topic)) {
-      console.warn('[useHelp] Invalid help topic:', topic)
       return null
     }
 
@@ -62,10 +61,10 @@ export const useHelp = () => {
    */
   const saveScrollPosition = (): void => {
     try {
-      savedScrollPosition = window.pageYOffset || document.documentElement.scrollTop
-      console.debug('[useHelp] Saved scroll position:', savedScrollPosition)
+      savedScrollPosition = window.pageYOffset
+        || document.documentElement.scrollTop
     } catch (error) {
-      console.warn('[useHelp] Failed to save scroll position:', error)
+      handleSilentError(error, 'useHelp.saveScrollPosition')
     }
   }
 
@@ -76,11 +75,12 @@ export const useHelp = () => {
     try {
       if (savedScrollPosition > 0) {
         window.scrollTo(0, savedScrollPosition)
-        console.debug('[useHelp] Restored scroll position:', savedScrollPosition)
         savedScrollPosition = 0
       }
     } catch (error) {
-      console.warn('[useHelp] Failed to restore scroll position:', error)
+      handleSilentError(
+        error, 'useHelp.restoreScrollPosition'
+      )
     }
   }
 
@@ -90,9 +90,8 @@ export const useHelp = () => {
   const saveFocus = (): void => {
     try {
       previousActiveElement = document.activeElement as HTMLElement
-      console.debug('[useHelp] Saved focus element:', previousActiveElement?.tagName ?? '')
     } catch (error) {
-      console.warn('[useHelp] Failed to save focus:', error)
+      handleSilentError(error, 'useHelp.saveFocus')
     }
   }
 
@@ -103,11 +102,10 @@ export const useHelp = () => {
     try {
       if (previousActiveElement && previousActiveElement.focus) {
         previousActiveElement.focus()
-        console.debug('[useHelp] Restored focus to:', previousActiveElement.tagName)
         previousActiveElement = null
       }
     } catch (error) {
-      console.warn('[useHelp] Failed to restore focus:', error)
+      handleSilentError(error, 'useHelp.restoreFocus')
     }
   }
 
@@ -116,12 +114,9 @@ export const useHelp = () => {
    * @param topic - Optional help topic to display
    */
   const showHelp = async (topic?: HelpTopic): Promise<void> => {
-    const startTime = performance.now()
-
     try {
       // Enhanced singleton enforcement
       if (isModalOpen.value || isCreating) {
-        console.warn('[useHelp] Modal already open, preventing duplicate')
         if (currentModal) {
           try {
             // Try to focus first focusable element within the modal
@@ -131,7 +126,7 @@ export const useHelp = () => {
             )
             el?.focus()
           } catch {
-            console.debug('[useHelp] Could not focus existing help modal')
+            // Could not focus existing help modal
           }
         }
         return
@@ -139,11 +134,6 @@ export const useHelp = () => {
 
       // Validate topic
       const validatedTopic = validateTopic(topic)
-
-      // Opening help modal
-      console.log('[useHelp] Opening help modal', {
-        topic: validatedTopic ?? null
-      })
 
       // Save current state
       saveScrollPosition()
@@ -165,7 +155,7 @@ export const useHelp = () => {
           animated: true
         })
       } catch (createError) {
-        console.error('[useHelp] Failed to create modal:', createError)
+        handleSilentError(createError, 'useHelp.showHelp')
         // Attempt recovery
         currentModal = null
         isModalOpen.value = false
@@ -183,10 +173,7 @@ export const useHelp = () => {
       // Enhanced dismissal handling
       currentModal
         .onDidDismiss()
-        .then((result: unknown) => {
-          const duration = Date.now() - modalOpenTime.value
-          console.log('[useHelp] Modal dismissed', { duration, result })
-          // Modal dismissed
+        .then(() => {
           currentModal = null
           isModalOpen.value = false
           modalOpenTime.value = 0
@@ -196,7 +183,7 @@ export const useHelp = () => {
           restoreFocus()
         })
         .catch((error: unknown) => {
-          console.error('[useHelp] Error in dismiss handler:', error)
+          handleSilentError(error, 'useHelp.showHelp.dismiss')
           currentModal = null
           isModalOpen.value = false
           modalOpenTime.value = 0
@@ -205,19 +192,8 @@ export const useHelp = () => {
       // Present with error handling
       await currentModal.present()
 
-      const loadTime = performance.now() - startTime
-      const formattedLoadTime = loadTime.toFixed(2)
-      // Modal presented successfully
-      console.log('[useHelp] Modal presented successfully', {
-        loadTime: `${formattedLoadTime}ms`
-      })
-
-      // Performance warning
-      if (loadTime > 200) {
-        console.warn('[useHelp] Modal took longer than 200ms to open:', `${formattedLoadTime}ms`)
-      }
     } catch (error) {
-      console.error('[useHelp] Error showing help modal:', error)
+      handleSilentError(error, 'useHelp.showHelp')
       currentModal = null
       isModalOpen.value = false
       modalOpenTime.value = 0
@@ -243,15 +219,10 @@ export const useHelp = () => {
   const hideHelp = async (): Promise<void> => {
     try {
       if (currentModal) {
-        // Hiding help modal
-        console.log('[useHelp] Hiding help modal')
         await currentModal.dismiss()
-      } else {
-        // No modal to hide
-        console.log('[useHelp] No modal to hide')
       }
     } catch (error) {
-      console.error('[useHelp] Error hiding help modal:', error)
+      handleSilentError(error, 'useHelp.hideHelp')
       // Clean up state even if dismiss fails
       currentModal = null
       isModalOpen.value = false
@@ -272,7 +243,6 @@ export const useHelp = () => {
   const setupKeyboardHandlers = (): void => {
     const handleEscape = async (event: KeyboardEvent) => {
       if (event.key === 'Escape' && isModalOpen.value) {
-        console.debug('[useHelp] Escape key pressed, closing modal')
         await hideHelp()
       }
     }

--- a/app/composables/useHelp.ts
+++ b/app/composables/useHelp.ts
@@ -61,8 +61,7 @@ export const useHelp = () => {
    */
   const saveScrollPosition = (): void => {
     try {
-      savedScrollPosition = window.pageYOffset
-        || document.documentElement.scrollTop
+      savedScrollPosition = window.pageYOffset || document.documentElement.scrollTop
     } catch (error) {
       handleSilentError(error, 'useHelp.saveScrollPosition')
     }
@@ -78,9 +77,7 @@ export const useHelp = () => {
         savedScrollPosition = 0
       }
     } catch (error) {
-      handleSilentError(
-        error, 'useHelp.restoreScrollPosition'
-      )
+      handleSilentError(error, 'useHelp.restoreScrollPosition')
     }
   }
 
@@ -154,9 +151,7 @@ export const useHelp = () => {
           showBackdrop: true,
           animated: true
         })
-      } catch (createError) {
-        handleSilentError(createError, 'useHelp.showHelp')
-        // Attempt recovery
+      } catch {
         currentModal = null
         isModalOpen.value = false
         throw new Error(
@@ -191,7 +186,6 @@ export const useHelp = () => {
 
       // Present with error handling
       await currentModal.present()
-
     } catch (error) {
       handleSilentError(error, 'useHelp.showHelp')
       currentModal = null

--- a/app/composables/useI18n.ts
+++ b/app/composables/useI18n.ts
@@ -1,6 +1,8 @@
 import { useI18n } from 'vue-i18n'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 export const useAppI18n = () => {
+  const { handleSilentError } = useErrorHandler()
   const { $i18n } = useNuxtApp()
   const i18n = useI18n()
   const localePath = useLocalePath()
@@ -27,7 +29,7 @@ export const useAppI18n = () => {
         replace: true
       })
     } catch (error) {
-      console.warn('Failed to switch language:', error)
+      handleSilentError(error, 'useI18n.switchLanguage')
       // Fallback to setting locale without navigation
       await i18n.setLocale(locale as 'en' | 'es' | 'fr' | 'de' | 'pt')
     }

--- a/app/composables/useLog.ts
+++ b/app/composables/useLog.ts
@@ -158,8 +158,6 @@ export const useLog = () => {
       if (options?.throwOnError) {
         throw err
       }
-      // Content logs are often non-critical, so we just log the error
-      console.error(t('errors.log.contentActionFailedLog'), err)
       handleError(err, { source: 'useLog.logContentAction' })
     }
   }
@@ -179,8 +177,6 @@ export const useLog = () => {
       if (options?.throwOnError) {
         throw err
       }
-      // User action logs are often non-critical
-      console.error(t('errors.log.userActionFailedLog'), err)
       handleError(err, { source: 'useLog.logUserAction' })
     }
   }

--- a/app/composables/useMetrics.ts
+++ b/app/composables/useMetrics.ts
@@ -1,6 +1,7 @@
 import { MetricsService } from './api/services/MetricsService'
 import { MetricCategory } from '../../shared/types/models/metrics'
 import type { MetricData } from '../../shared/types/models/metrics'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 // NetworkInformation API type (experimental browser API)
 interface NetworkInformation {
@@ -15,6 +16,7 @@ interface NetworkInformation {
  * Provides a lightweight, non-blocking way to send metrics to the backend
  */
 export const useMetrics = () => {
+  const { handleSilentError } = useErrorHandler()
   // Use Nuxt's built-in state management for SSR safety
   const metricsService = useState<MetricsService>('metricsService', () => {
     return new MetricsService()
@@ -85,8 +87,7 @@ export const useMetrics = () => {
         throw error
       }
     } catch (error) {
-      // Metrics are non-critical, so we just log the error with context
-      console.error(`Error sending ${metricData.category} metric:`, error)
+      handleSilentError(error, 'useMetrics.sendMetric')
       return false
     }
   }

--- a/app/composables/useProfileEdit.ts
+++ b/app/composables/useProfileEdit.ts
@@ -4,6 +4,7 @@ import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'
 import { UserService } from './api/services/UserService'
 import type { UpdateUserRequest } from '../../shared/types'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 export type ProfileEditForm = {
   name: string
@@ -15,6 +16,7 @@ export const useProfileEdit = () => {
   const { user, refreshProfile } = useProfile()
   const { t } = useI18n()
   const userService = new UserService()
+  const { handleError } = useErrorHandler()
 
   const profileEditSchema = z.object({
     name: z.string().min(1, t('validation.profile.nameRequired')),
@@ -127,7 +129,7 @@ export const useProfileEdit = () => {
 
       isEditing.value = false
     } catch (err: unknown) {
-      console.error(t('errors.account.updateProfileLog'), err)
+      handleError(err, { source: 'useProfileEdit.updateProfile' })
       error.value = err instanceof Error ? err.message : t('account.profile.updateError')
 
       const toast = await useToast().create({

--- a/app/composables/useProfileEdit.ts
+++ b/app/composables/useProfileEdit.ts
@@ -16,7 +16,7 @@ export const useProfileEdit = () => {
   const { user, refreshProfile } = useProfile()
   const { t } = useI18n()
   const userService = new UserService()
-  const { handleError } = useErrorHandler()
+  const { handleSilentError } = useErrorHandler()
 
   const profileEditSchema = z.object({
     name: z.string().min(1, t('validation.profile.nameRequired')),
@@ -129,7 +129,7 @@ export const useProfileEdit = () => {
 
       isEditing.value = false
     } catch (err: unknown) {
-      handleError(err, { source: 'useProfileEdit.updateProfile' })
+      handleSilentError(err, 'useProfileEdit.updateProfile')
       error.value = err instanceof Error ? err.message : t('account.profile.updateError')
 
       const toast = await useToast().create({

--- a/app/composables/useSafeLocalePath.ts
+++ b/app/composables/useSafeLocalePath.ts
@@ -37,7 +37,14 @@ const pathCache = new Map<string, string>()
  * ```
  */
 export const useSafeLocalePath = () => {
-  const { handleSilentError } = useErrorHandler()
+  const silentError = (error: unknown, source: string) => {
+    try {
+      const { handleSilentError } = useErrorHandler()
+      handleSilentError(error, source)
+    } catch {
+      // useErrorHandler unavailable — silently ignore
+    }
+  }
   let localePath: ReturnType<typeof useLocalePath> | null = null
   let currentLocale: Ref<string> | null = null
 
@@ -47,7 +54,7 @@ export const useSafeLocalePath = () => {
     const { locale } = useI18n()
     currentLocale = locale
   } catch (error) {
-    handleSilentError(error, 'useSafeLocalePath.init')
+    silentError(error, 'useSafeLocalePath.init')
   }
 
   /**
@@ -120,7 +127,7 @@ export const useSafeLocalePath = () => {
         try {
           resolvedPath = localePath(route, locale)
         } catch (error) {
-          handleSilentError(error, 'useSafeLocalePath.resolve')
+          silentError(error, 'useSafeLocalePath.resolve')
           resolvedPath = fallbackPathResolver(route, locale)
         }
       } else {
@@ -139,7 +146,7 @@ export const useSafeLocalePath = () => {
 
       return resolvedPath
     } catch (error) {
-      handleSilentError(error, 'useSafeLocalePath.resolve')
+      silentError(error, 'useSafeLocalePath.resolve')
 
       // Ultimate fallback: return original path or root
       if (typeof route === 'string') {

--- a/app/composables/useSafeLocalePath.ts
+++ b/app/composables/useSafeLocalePath.ts
@@ -1,6 +1,7 @@
 import { useI18n } from 'vue-i18n'
 import type { RouteLocationRaw } from 'vue-router'
 import type { Ref } from 'vue'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 /**
  * Type definitions for route handling
@@ -36,6 +37,7 @@ const pathCache = new Map<string, string>()
  * ```
  */
 export const useSafeLocalePath = () => {
+  const { handleSilentError } = useErrorHandler()
   let localePath: ReturnType<typeof useLocalePath> | null = null
   let currentLocale: Ref<string> | null = null
 
@@ -45,7 +47,7 @@ export const useSafeLocalePath = () => {
     const { locale } = useI18n()
     currentLocale = locale
   } catch (error) {
-    console.warn('useLocalePath not available:', error)
+    handleSilentError(error, 'useSafeLocalePath.init')
   }
 
   /**
@@ -92,7 +94,6 @@ export const useSafeLocalePath = () => {
       // If it has a name property, return as is
       // (named routes need proper i18n setup)
       if (routeObj.name && typeof routeObj.name === 'string') {
-        console.warn(`Named route "${routeObj.name}" requires i18n setup`)
         return routeObj.name
       }
     }
@@ -119,7 +120,7 @@ export const useSafeLocalePath = () => {
         try {
           resolvedPath = localePath(route, locale)
         } catch (error) {
-          console.warn('Failed to resolve path with localePath:', error)
+          handleSilentError(error, 'useSafeLocalePath.resolve')
           resolvedPath = fallbackPathResolver(route, locale)
         }
       } else {
@@ -138,7 +139,7 @@ export const useSafeLocalePath = () => {
 
       return resolvedPath
     } catch (error) {
-      console.error('Failed to resolve localized path:', error)
+      handleSilentError(error, 'useSafeLocalePath.resolve')
 
       // Ultimate fallback: return original path or root
       if (typeof route === 'string') {

--- a/app/composables/useTextFormatting.ts
+++ b/app/composables/useTextFormatting.ts
@@ -1,5 +1,6 @@
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 // TypeScript interface for extracted links
 export interface ExtractedLink {
@@ -8,6 +9,7 @@ export interface ExtractedLink {
 }
 
 export const useTextFormatting = () => {
+  const { handleSilentError } = useErrorHandler()
   // Configure marked with safe defaults
   marked.setOptions({
     breaks: true, // Convert line breaks to <br>
@@ -60,7 +62,9 @@ export const useTextFormatting = () => {
 
       return cleanHtml
     } catch (error) {
-      console.warn('Error formatting markdown:', error)
+      handleSilentError(
+        error, 'useTextFormatting.formatMarkdown'
+      )
       // Fallback to plain text
       return DOMPurify.sanitize(text)
     }
@@ -117,7 +121,7 @@ export const useTextFormatting = () => {
         }
       }
     } catch (error) {
-      console.warn('Error extracting URLs:', error)
+      handleSilentError(error, 'useTextFormatting.extractUrls')
     }
 
     return links

--- a/app/composables/useTextFormatting.ts
+++ b/app/composables/useTextFormatting.ts
@@ -62,9 +62,7 @@ export const useTextFormatting = () => {
 
       return cleanHtml
     } catch (error) {
-      handleSilentError(
-        error, 'useTextFormatting.formatMarkdown'
-      )
+      handleSilentError(error, 'useTextFormatting.formatMarkdown')
       // Fallback to plain text
       return DOMPurify.sanitize(text)
     }

--- a/app/composables/useUserRole.ts
+++ b/app/composables/useUserRole.ts
@@ -1,4 +1,5 @@
 import type { User } from '../../shared/types'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 /**
  * Composable for checking user roles and permissions
@@ -14,6 +15,7 @@ import type { User } from '../../shared/types'
  */
 export const useUserRole = () => {
   const authStore = useAuthStore()
+  const { handleSilentError } = useErrorHandler()
 
   /**
    * Get cached role data from localStorage (set by auth store)
@@ -36,7 +38,10 @@ export const useUserRole = () => {
     try {
       // Check if localStorage is available
       if (typeof window === 'undefined' || !window.localStorage) {
-        console.warn('[useUserRole] localStorage not available')
+        handleSilentError(
+          new Error('localStorage not available'),
+          'useUserRole.loadRole'
+        )
         return defaultRoleData
       }
 
@@ -61,11 +66,10 @@ export const useUserRole = () => {
         ) {
           return parsed
         } else {
-          console.warn('[useUserRole] Invalid role data structure')
           return defaultRoleData
         }
       } catch (parseError) {
-        console.error('[useUserRole] Failed to parse role data:', parseError)
+        handleSilentError(parseError, 'useUserRole.loadRole')
         // Clear invalid data
         try {
           storage.remove('auth_active_company_roles')
@@ -75,16 +79,7 @@ export const useUserRole = () => {
         return defaultRoleData
       }
     } catch (error) {
-      // Handle localStorage access errors (disabled, quota exceeded, etc.)
-      if (error instanceof Error) {
-        if (error.name === 'QuotaExceededError') {
-          console.error('[useUserRole] localStorage quota exceeded')
-        } else if (error.name === 'SecurityError') {
-          console.error('[useUserRole] localStorage access denied')
-        } else {
-          console.error('[useUserRole] localStorage error:', error.message)
-        }
-      }
+      handleSilentError(error, 'useUserRole.saveRole')
       return defaultRoleData
     }
   }

--- a/app/composables/useUserRole.ts
+++ b/app/composables/useUserRole.ts
@@ -38,10 +38,6 @@ export const useUserRole = () => {
     try {
       // Check if localStorage is available
       if (typeof window === 'undefined' || !window.localStorage) {
-        handleSilentError(
-          new Error('localStorage not available'),
-          'useUserRole.loadRole'
-        )
         return defaultRoleData
       }
 
@@ -79,7 +75,7 @@ export const useUserRole = () => {
         return defaultRoleData
       }
     } catch (error) {
-      handleSilentError(error, 'useUserRole.saveRole')
+      handleSilentError(error, 'useUserRole.loadRole')
       return defaultRoleData
     }
   }

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -21,8 +21,6 @@ export default defineNuxtRouteMiddleware(async _to => {
     try {
       await authStore.ensureProfileData(true)
     } catch (error) {
-      console.error('[AUTH_MIDDLEWARE] Failed to bootstrap profile data:', error)
-
       // If profile fetch fails critically, redirect to error page
       // Check if it's a network error or authentication issue
       const isNetworkError =
@@ -49,9 +47,8 @@ export default defineNuxtRouteMiddleware(async _to => {
         return navigateTo(localePath('/error?type=profile&retry=profile'))
       }
     }
-  } catch (error) {
+  } catch {
     // If Pinia isn't ready yet, redirect to login as fallback
-    console.warn('Auth store not ready in auth middleware:', error)
     const localePath = useLocalePath()
     return navigateTo(localePath('/login'))
   }

--- a/app/middleware/guest.ts
+++ b/app/middleware/guest.ts
@@ -16,8 +16,7 @@ export default defineNuxtRouteMiddleware(_to => {
       const localePath = useLocalePath()
       return navigateTo(localePath('/main'))
     }
-  } catch (error) {
+  } catch {
     // If Pinia isn't ready yet, just continue
-    console.warn('Auth store not ready in guest middleware:', error)
   }
 })

--- a/app/middleware/layout.global.ts
+++ b/app/middleware/layout.global.ts
@@ -12,7 +12,6 @@ export default defineNuxtRouteMiddleware(to => {
     // Ensure Pinia is available before trying to use stores
     const nuxtApp = useNuxtApp()
     if (!nuxtApp.$pinia) {
-      console.warn('Pinia not yet initialized, defaulting to public layout')
       to.meta.layout = 'public'
       return
     }
@@ -27,8 +26,7 @@ export default defineNuxtRouteMiddleware(to => {
     authStore.initializeAuth()
 
     to.meta.layout = authStore.isAuthenticated ? 'private' : 'public'
-  } catch (error) {
-    console.error('Layout middleware error:', error)
+  } catch {
     to.meta.layout = 'public'
   }
 })

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -568,8 +568,8 @@ const isPasswordValid = computed(() => {
 const loadProfileData = async () => {
   try {
     await ensureProfileData()
-  } catch (err: unknown) {
-    console.error('Error loading profile:', err)
+  } catch {
+    // Error handled by useProfile
   }
 }
 
@@ -603,8 +603,7 @@ const updatePassword = async () => {
       newPassword: '',
       confirmPassword: ''
     }
-  } catch (err: unknown) {
-    console.error('Error updating password:', err)
+  } catch {
     const errorToast = await useToast().create({
       message: t('account.password.updateError'),
       duration: 4000,

--- a/app/pages/main.vue
+++ b/app/pages/main.vue
@@ -79,6 +79,7 @@
 import { useI18n } from 'vue-i18n'
 import { debounce } from '../utils/helpers'
 import { useSafeLocalePath } from '~/composables/useSafeLocalePath'
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
 definePageMeta({
   middleware: 'auth'
@@ -89,6 +90,7 @@ const { error: errorIcon, person } = useIcons()
 const router = useRouter()
 const { t } = useI18n()
 const { localePath } = useSafeLocalePath()
+const { handleSilentError } = useErrorHandler()
 
 // Navigation state management
 const navigationLoading = ref(false)
@@ -126,7 +128,7 @@ const navigateToRoute = async (route: string) => {
     try {
       await router.push(localePath(route))
     } catch (err) {
-      console.error(t('errors.navigationErrorLog'), err)
+      handleSilentError(err, 'main.navigate')
       // Set error message for screen readers
       const fallbackMessage = err instanceof Error ? err.message : t('errors.navigationFailed')
       navigationError.value = `${t('common.error')}: ${fallbackMessage}`

--- a/app/plugins/swiper.client.ts
+++ b/app/plugins/swiper.client.ts
@@ -4,7 +4,7 @@ export default defineNuxtPlugin(async () => {
     const { register } = await import('swiper/element/bundle')
     // Register Swiper custom elements globally
     register()
-  } catch (error) {
-    console.warn('Swiper element bundle not found, skipping registration:', error)
+  } catch {
+    // Swiper element bundle not found, skipping registration
   }
 })

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -203,10 +203,7 @@ export const useAuthStore = defineStore('auth', () => {
         // Handle localStorage errors (quota exceeded, disabled, etc.)
         if (error instanceof Error) {
           if (error.name === 'QuotaExceededError') {
-            handleSilentError(
-              new Error('localStorage quota exceeded'),
-              'authStore.persistRoleData'
-            )
+            handleSilentError(error, 'authStore.persistRoleData')
             try {
               const storage = useStorage()
               // Clear old data to make room
@@ -218,8 +215,8 @@ export const useAuthStore = defineStore('auth', () => {
                 operators: []
               })
               storage.set('auth_active_company_roles', minimalData)
-            } catch {
-              // Unable to store role data
+            } catch (retryError) {
+              handleSilentError(retryError, 'authStore.persistRoleData')
             }
           } else {
             handleSilentError(error, 'authStore.persistRoleData')
@@ -270,10 +267,7 @@ export const useAuthStore = defineStore('auth', () => {
           const firstCompanyId = firstCompany ? firstCompany._id || firstCompany.id : null
 
           if (!firstCompanyId) {
-            handleSilentError(
-              new Error('First company has no valid ID'),
-              'authStore.fetchProfile'
-            )
+            handleSilentError(new Error('First company has no valid ID'), 'authStore.fetchProfile')
             // Fallback: set company locally without API update
             setProfileState(profile)
           } else {

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -1,7 +1,9 @@
 import type { User, Company } from '../../shared/types'
 import { retry } from '~/utils/helpers'
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
 export const useAuthStore = defineStore('auth', () => {
+  const { handleError, handleSilentError } = useErrorHandler()
   const user = ref<User | null>(null)
   const token = ref<string | null>(null)
   const activeCompany = ref<Company | null>(null)
@@ -86,7 +88,7 @@ export const useAuthStore = defineStore('auth', () => {
       try {
         user.value = JSON.parse(savedUser)
       } catch (error) {
-        console.error('Failed to parse saved user data:', error)
+        handleSilentError(error, 'authStore.hydrate')
         storage.remove('auth_user')
       }
     }
@@ -95,7 +97,7 @@ export const useAuthStore = defineStore('auth', () => {
       try {
         activeCompany.value = JSON.parse(savedActiveCompany)
       } catch (error) {
-        console.error('Failed to parse saved active company data:', error)
+        handleSilentError(error, 'authStore.hydrate')
         storage.remove('auth_active_company')
       }
     }
@@ -104,7 +106,7 @@ export const useAuthStore = defineStore('auth', () => {
       try {
         otherCompanies.value = JSON.parse(savedOtherCompanies)
       } catch (error) {
-        console.error('Failed to parse saved other companies data:', error)
+        handleSilentError(error, 'authStore.hydrate')
         storage.remove('auth_other_companies')
       }
     }
@@ -113,7 +115,7 @@ export const useAuthStore = defineStore('auth', () => {
       try {
         lastProfileFetch.value = parseInt(savedLastProfileFetch) || 0
       } catch (error) {
-        console.error('Failed to parse saved last profile fetch time:', error)
+        handleSilentError(error, 'authStore.hydrate')
         storage.remove('auth_last_profile_fetch')
       }
     }
@@ -181,7 +183,6 @@ export const useAuthStore = defineStore('auth', () => {
 
         // Check if data size is reasonable (< 100KB)
         if (roleData.length > 100000) {
-          console.warn('[AUTH] Role data too large for localStorage, storing summary only')
           // Store only IDs if data is too large
           const summaryData = JSON.stringify({
             admins: (profile.active_company.admins || [])
@@ -202,7 +203,10 @@ export const useAuthStore = defineStore('auth', () => {
         // Handle localStorage errors (quota exceeded, disabled, etc.)
         if (error instanceof Error) {
           if (error.name === 'QuotaExceededError') {
-            console.error('[AUTH] localStorage quota exceeded, clearing old data')
+            handleSilentError(
+              new Error('localStorage quota exceeded'),
+              'authStore.persistRoleData'
+            )
             try {
               const storage = useStorage()
               // Clear old data to make room
@@ -215,10 +219,10 @@ export const useAuthStore = defineStore('auth', () => {
               })
               storage.set('auth_active_company_roles', minimalData)
             } catch {
-              console.error('[AUTH] Unable to store role data in localStorage')
+              // Unable to store role data
             }
           } else {
-            console.error('[AUTH] Failed to store role data:', error.message)
+            handleSilentError(error, 'authStore.persistRoleData')
           }
         }
       }
@@ -266,7 +270,10 @@ export const useAuthStore = defineStore('auth', () => {
           const firstCompanyId = firstCompany ? firstCompany._id || firstCompany.id : null
 
           if (!firstCompanyId) {
-            console.error('[AUTH] First company has no valid ID')
+            handleSilentError(
+              new Error('First company has no valid ID'),
+              'authStore.fetchProfile'
+            )
             // Fallback: set company locally without API update
             setProfileState(profile)
           } else {
@@ -280,16 +287,12 @@ export const useAuthStore = defineStore('auth', () => {
                 1000 // delay between attempts
               )
 
-              // Successfully auto-selected company
-              console.log('[AUTH] Successfully auto-selected company')
-
               // Update state from fresh response
               setProfileState(updatedProfile)
             } catch (error) {
-              console.error('[AUTH] Failed to auto-select company:', error)
+              handleSilentError(error, 'authStore.fetchProfile')
 
               // Fallback: set company locally without API update
-              // Using local fallback for company selection
               // Manually construct the active_company structure
               const activeCompanyId =
                 firstCompany?._id ?? (firstCompany?.id != null ? String(firstCompany.id) : null)
@@ -315,7 +318,6 @@ export const useAuthStore = defineStore('auth', () => {
                     return !activeCompanyId || otherId !== activeCompanyId
                   })
                 }
-              console.log('[AUTH] Using local fallback for company selection')
               setProfileState(fallbackProfile)
             }
           }
@@ -337,7 +339,7 @@ export const useAuthStore = defineStore('auth', () => {
           otherCompanies: otherCompanies.value
         }
       } catch (error) {
-        console.error('[AUTH] Failed to fetch profile:', error)
+        handleError(error, { source: 'authStore.fetchProfile' })
         // Ensure cleanup happens even on error
         if (!cleanupDone) {
           profileFetchPromise.value = null

--- a/app/utils/helpers.ts
+++ b/app/utils/helpers.ts
@@ -148,7 +148,6 @@ export const isValidRegex = (pattern: string): boolean => {
       if (nestedQuantifier.test(pattern) || nestedBraces.test(pattern)) {
         // But allow safe patterns like (/path)*
         if (!/\(\/[^)]*\)\*/.test(pattern)) {
-          console.warn('Potentially dangerous regex pattern detected')
           return false
         }
       }
@@ -174,7 +173,6 @@ export const createSafeRegex = (pattern: string, flags = ''): RegExp | null => {
       if (nestedQuantifier.test(pattern) || nestedBraces.test(pattern)) {
         // But allow safe patterns like (/path)*
         if (!/\(\/[^)]*\)\*/.test(pattern)) {
-          console.warn('Potentially dangerous regex pattern detected')
           return null
         }
       }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,3 +42,7 @@ export default createConfigForNuxt({
       '**/.claude/**'
     ]
   })
+  .append({
+    files: ['app/**/*.{ts,vue}'],
+    rules: { 'no-console': 'error' }
+  })

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -236,6 +236,8 @@
   },
   "errors": {
     "generic": "Etwas ist schief gelaufen",
+    "api": { "generic": "Serverfehler aufgetreten" },
+    "validation": { "generic": "Bitte beheben Sie die Formularfehler unten" },
     "networkError": "Netzwerkfehler. Bitte überprüfen Sie Ihre Verbindung.",
     "unauthorized": "Nicht autorisierter Zugriff",
     "forbidden": "Sie haben keine Berechtigung, auf diese Ressource zuzugreifen",

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -237,6 +237,8 @@
   },
   "errors": {
     "generic": "Algo salió mal",
+    "api": { "generic": "Se produjo un error en el servidor" },
+    "validation": { "generic": "Por favor corrija los errores del formulario" },
     "networkError": "Error de red. Por favor verifica tu conexión.",
     "unauthorized": "Acceso no autorizado",
     "forbidden": "No tienes permiso para acceder a este recurso",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -236,6 +236,8 @@
   },
   "errors": {
     "generic": "Une erreur s'est produite",
+    "api": { "generic": "Erreur serveur survenue" },
+    "validation": { "generic": "Veuillez corriger les erreurs du formulaire" },
     "networkError": "Erreur réseau. Veuillez vérifier votre connexion.",
     "unauthorized": "Accès non autorisé",
     "forbidden": "Vous n'avez pas la permission d'accéder à cette ressource",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -236,6 +236,8 @@
   },
   "errors": {
     "generic": "Algo deu errado",
+    "api": { "generic": "Ocorreu um erro no servidor" },
+    "validation": { "generic": "Por favor corrija os erros do formulário" },
     "networkError": "Erro de rede. Por favor, verifique sua conexão.",
     "unauthorized": "Acesso não autorizado",
     "forbidden": "Você não tem permissão para acessar este recurso",

--- a/tests/unit/composables/errors/useErrorHandler.test.ts
+++ b/tests/unit/composables/errors/useErrorHandler.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flushPromises } from '../../../setup/test-setup'
+
+const presentSpy = vi.fn()
+const createSpy = vi.fn(
+  () => Promise.resolve({ present: presentSpy })
+)
+
+// Override global useToast before composable import
+global.useToast = () => ({ create: createSpy })
+
+// eslint-disable-next-line import/first -- must follow useToast override
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
+
+// NOTE: import.meta.dev is statically replaced to false by Vitest at
+// transform time. Tests that verify console.error logging in dev mode
+// require `define: { 'import.meta.dev': true }` in vitest.config.mjs.
+// Those tests are marked .skip until the config is updated.
+
+describe('useErrorHandler', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'error')
+      .mockImplementation(() => {})
+    createSpy.mockClear()
+    presentSpy.mockClear()
+  })
+
+  afterEach(() => {
+    consoleSpy.mockRestore()
+  })
+
+  describe('normalizeError', () => {
+    it('normalizes FetchError with data.message', () => {
+      const { normalizeError } = useErrorHandler()
+      const fetchError = {
+        data: { message: 'Not Found' },
+        statusCode: 404
+      }
+
+      const result = normalizeError(fetchError)
+
+      expect(result.message).toBe('Not Found')
+      expect(result.source).toBe('api')
+      expect(result.code).toBe(404)
+      expect(result.details).toEqual({ message: 'Not Found' })
+      expect(result.timestamp).toBeInstanceOf(Date)
+    })
+
+    it('normalizes FetchError without data.message to i18n key', () => {
+      const { normalizeError } = useErrorHandler()
+      const fetchError = { data: {}, statusCode: 500 }
+
+      const result = normalizeError(fetchError)
+
+      expect(result.message).toBe('errors.api.generic')
+      expect(result.source).toBe('api')
+      expect(result.code).toBe(500)
+      expect(result.timestamp).toBeInstanceOf(Date)
+    })
+
+    it('normalizes validation error with issues', () => {
+      const { normalizeError } = useErrorHandler()
+      const issues = [{ path: 'email', message: 'required' }]
+
+      const result = normalizeError({ issues })
+
+      expect(result.source).toBe('validation')
+      expect(result.code).toBe('VALIDATION_ERROR')
+      expect(result.details).toEqual(issues)
+      expect(result.timestamp).toBeInstanceOf(Date)
+    })
+
+    it('normalizes validation error with errors variant', () => {
+      const { normalizeError } = useErrorHandler()
+      const errors = [{ field: 'name', msg: 'too short' }]
+
+      const result = normalizeError({ errors })
+
+      expect(result.source).toBe('validation')
+      expect(result.code).toBe('VALIDATION_ERROR')
+      expect(result.details).toEqual(errors)
+      expect(result.timestamp).toBeInstanceOf(Date)
+    })
+
+    it('normalizes standard Error instance', () => {
+      const { normalizeError } = useErrorHandler()
+      const error = new Error('boom')
+
+      const result = normalizeError(error)
+
+      expect(result.source).toBe('system')
+      expect(result.message).toBe('boom')
+      expect(result.code).toBe('UNKNOWN_ERROR')
+      expect(result.details).toHaveProperty('name', 'Error')
+      expect(result.details).toHaveProperty('stack')
+      expect(result.timestamp).toBeInstanceOf(Date)
+    })
+
+    it('normalizes primitives to unknown source', () => {
+      const { normalizeError } = useErrorHandler()
+
+      const strResult = normalizeError('str' as unknown)
+      expect(strResult.source).toBe('unknown')
+      expect(strResult.message).toBe('errors.generic')
+      expect(strResult.timestamp).toBeInstanceOf(Date)
+
+      const numResult = normalizeError(42 as unknown)
+      expect(numResult.source).toBe('unknown')
+      expect(numResult.timestamp).toBeInstanceOf(Date)
+
+      const nullResult = normalizeError(null as unknown)
+      expect(nullResult.source).toBe('unknown')
+      expect(nullResult.timestamp).toBeInstanceOf(Date)
+    })
+  })
+
+  describe('handleError', () => {
+    it('shows toast by default with correct options', async () => {
+      const { handleError } = useErrorHandler()
+
+      handleError(new Error('test error'))
+      await flushPromises()
+
+      expect(createSpy).toHaveBeenCalledWith({
+        message: 'test error',
+        color: 'danger',
+        duration: 4000,
+        position: 'top'
+      })
+      expect(presentSpy).toHaveBeenCalled()
+    })
+
+    it('does not show toast when toast option is false', () => {
+      const { handleError } = useErrorHandler()
+
+      handleError(new Error('silent'), { toast: false })
+
+      expect(createSpy).not.toHaveBeenCalled()
+    })
+
+    // Requires import.meta.dev=true in vitest config define
+    it(
+      'logs to console in dev mode with source',
+      () => {
+        const { handleError } = useErrorHandler()
+
+        handleError(new Error('oops'), {
+          console: true,
+          source: 'TestModule'
+        })
+
+        expect(consoleSpy).toHaveBeenCalled()
+        const msg = consoleSpy.mock.calls[0][0] as string
+        expect(msg).toMatch(
+          /^\[SYSTEM\] Error in TestModule:/
+        )
+      }
+    )
+
+    it('does not log to console when console option is false', () => {
+      const { handleError } = useErrorHandler()
+
+      handleError(new Error('no log'), { console: false })
+
+      expect(consoleSpy).not.toHaveBeenCalled()
+    })
+
+    // Requires import.meta.dev=true in vitest config define
+    it(
+      'omits "in" from console message when no source',
+      () => {
+        const { handleError } = useErrorHandler()
+
+        handleError(new Error('no source'), {
+          console: true
+        })
+
+        expect(consoleSpy).toHaveBeenCalled()
+        const msg = consoleSpy.mock.calls[0][0] as string
+        expect(msg).toMatch(/^\[SYSTEM\] Error:/)
+        expect(msg).not.toContain(' in ')
+      }
+    )
+
+    it('returns normalized error matching shape', () => {
+      const { handleError, normalizeError } = useErrorHandler()
+      const error = new Error('shape test')
+
+      const result = handleError(error, {
+        toast: false,
+        console: false
+      })
+      const normalized = normalizeError(error)
+
+      expect(result.message).toBe(normalized.message)
+      expect(result.source).toBe(normalized.source)
+      expect(result.code).toBe(normalized.code)
+    })
+  })
+
+  describe('handleApiError', () => {
+    it('shows toast and returns api-normalized error', () => {
+      const { handleApiError } = useErrorHandler()
+      const fetchError = {
+        data: { message: 'Server Error' },
+        statusCode: 500
+      }
+
+      const result = handleApiError(fetchError as never)
+
+      expect(createSpy).toHaveBeenCalled()
+      expect(result.source).toBe('api')
+      expect(result.message).toBe('Server Error')
+      expect(result.code).toBe(500)
+    })
+
+    // Requires import.meta.dev=true in vitest config define
+    it(
+      'logs with API call as default source',
+      () => {
+        const { handleApiError } = useErrorHandler()
+        const fetchError = {
+          data: { message: 'Err' },
+          statusCode: 500
+        }
+
+        handleApiError(fetchError as never)
+
+        expect(consoleSpy).toHaveBeenCalled()
+        const msg = consoleSpy.mock.calls[0][0] as string
+        expect(msg).toContain('API call')
+      }
+    )
+  })
+
+  describe('handleValidationError', () => {
+    it('does not show toast and returns validation error', () => {
+      const { handleValidationError } = useErrorHandler()
+
+      const result = handleValidationError({
+        issues: [{ msg: 'required' }]
+      })
+
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(result.source).toBe('validation')
+      expect(result.code).toBe('VALIDATION_ERROR')
+    })
+
+    // Requires import.meta.dev=true in vitest config define
+    it(
+      'logs with Form validation as default source',
+      () => {
+        const { handleValidationError } = useErrorHandler()
+
+        handleValidationError({
+          issues: [{ msg: 'required' }]
+        })
+
+        expect(consoleSpy).toHaveBeenCalled()
+        const msg = consoleSpy.mock.calls[0][0] as string
+        expect(msg).toContain('Form validation')
+      }
+    )
+  })
+
+  describe('handleSilentError', () => {
+    it('does not show toast', () => {
+      const { handleSilentError } = useErrorHandler()
+
+      const result = handleSilentError(new Error('quiet'))
+
+      expect(createSpy).not.toHaveBeenCalled()
+      expect(result.source).toBe('system')
+      expect(result.message).toBe('quiet')
+    })
+
+    // Requires import.meta.dev=true in vitest config define
+    it(
+      'logs without default source label',
+      () => {
+        const { handleSilentError } = useErrorHandler()
+
+        handleSilentError(new Error('quiet'))
+
+        expect(consoleSpy).toHaveBeenCalled()
+        const msg = consoleSpy.mock.calls[0][0] as string
+        expect(msg).toMatch(/^\[SYSTEM\] Error:/)
+        expect(msg).not.toContain(' in ')
+      }
+    )
+  })
+})

--- a/tests/unit/composables/errors/useErrorHandler.test.ts
+++ b/tests/unit/composables/errors/useErrorHandler.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { flushPromises } from '../../../setup/test-setup'
 
 const presentSpy = vi.fn()
-const createSpy = vi.fn(
-  () => Promise.resolve({ present: presentSpy })
-)
+const createSpy = vi.fn(() => Promise.resolve({ present: presentSpy }))
 
 // Override global useToast before composable import
 global.useToast = () => ({ create: createSpy })
@@ -12,17 +10,14 @@ global.useToast = () => ({ create: createSpy })
 // eslint-disable-next-line import/first -- must follow useToast override
 import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
-// NOTE: import.meta.dev is statically replaced to false by Vitest at
-// transform time. Tests that verify console.error logging in dev mode
-// require `define: { 'import.meta.dev': true }` in vitest.config.mjs.
-// Those tests are marked .skip until the config is updated.
+// NOTE: import.meta.dev is statically replaced by Vitest via
+// `define: { 'import.meta.dev': true }` in vitest.config.mjs.
 
 describe('useErrorHandler', () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    consoleSpy = vi.spyOn(console, 'error')
-      .mockImplementation(() => {})
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     createSpy.mockClear()
     presentSpy.mockClear()
   })
@@ -140,24 +135,34 @@ describe('useErrorHandler', () => {
       expect(createSpy).not.toHaveBeenCalled()
     })
 
-    // Requires import.meta.dev=true in vitest config define
-    it(
-      'logs to console in dev mode with source',
-      () => {
+    it('does not create toast on server (non-client)', async () => {
+      const originalSSR = import.meta.env.SSR
+      import.meta.env.SSR = true
+
+      try {
         const { handleError } = useErrorHandler()
+        handleError(new Error('ssr error'))
+        await flushPromises()
 
-        handleError(new Error('oops'), {
-          console: true,
-          source: 'TestModule'
-        })
-
-        expect(consoleSpy).toHaveBeenCalled()
-        const msg = consoleSpy.mock.calls[0][0] as string
-        expect(msg).toMatch(
-          /^\[SYSTEM\] Error in TestModule:/
-        )
+        expect(createSpy).not.toHaveBeenCalled()
+      } finally {
+        import.meta.env.SSR = originalSSR
       }
-    )
+    })
+
+    // Requires import.meta.dev=true in vitest config define
+    it('logs to console in dev mode with source', () => {
+      const { handleError } = useErrorHandler()
+
+      handleError(new Error('oops'), {
+        console: true,
+        source: 'TestModule'
+      })
+
+      expect(consoleSpy).toHaveBeenCalled()
+      const msg = consoleSpy.mock.calls[0][0] as string
+      expect(msg).toMatch(/^\[SYSTEM\] Error in TestModule:/)
+    })
 
     it('does not log to console when console option is false', () => {
       const { handleError } = useErrorHandler()
@@ -168,21 +173,18 @@ describe('useErrorHandler', () => {
     })
 
     // Requires import.meta.dev=true in vitest config define
-    it(
-      'omits "in" from console message when no source',
-      () => {
-        const { handleError } = useErrorHandler()
+    it('omits "in" from console message when no source', () => {
+      const { handleError } = useErrorHandler()
 
-        handleError(new Error('no source'), {
-          console: true
-        })
+      handleError(new Error('no source'), {
+        console: true
+      })
 
-        expect(consoleSpy).toHaveBeenCalled()
-        const msg = consoleSpy.mock.calls[0][0] as string
-        expect(msg).toMatch(/^\[SYSTEM\] Error:/)
-        expect(msg).not.toContain(' in ')
-      }
-    )
+      expect(consoleSpy).toHaveBeenCalled()
+      const msg = consoleSpy.mock.calls[0][0] as string
+      expect(msg).toMatch(/^\[SYSTEM\] Error:/)
+      expect(msg).not.toContain(' in ')
+    })
 
     it('returns normalized error matching shape', () => {
       const { handleError, normalizeError } = useErrorHandler()
@@ -217,22 +219,19 @@ describe('useErrorHandler', () => {
     })
 
     // Requires import.meta.dev=true in vitest config define
-    it(
-      'logs with API call as default source',
-      () => {
-        const { handleApiError } = useErrorHandler()
-        const fetchError = {
-          data: { message: 'Err' },
-          statusCode: 500
-        }
-
-        handleApiError(fetchError as never)
-
-        expect(consoleSpy).toHaveBeenCalled()
-        const msg = consoleSpy.mock.calls[0][0] as string
-        expect(msg).toContain('API call')
+    it('logs with API call as default source', () => {
+      const { handleApiError } = useErrorHandler()
+      const fetchError = {
+        data: { message: 'Err' },
+        statusCode: 500
       }
-    )
+
+      handleApiError(fetchError as never)
+
+      expect(consoleSpy).toHaveBeenCalled()
+      const msg = consoleSpy.mock.calls[0][0] as string
+      expect(msg).toContain('API call')
+    })
   })
 
   describe('handleValidationError', () => {
@@ -249,20 +248,17 @@ describe('useErrorHandler', () => {
     })
 
     // Requires import.meta.dev=true in vitest config define
-    it(
-      'logs with Form validation as default source',
-      () => {
-        const { handleValidationError } = useErrorHandler()
+    it('logs with Form validation as default source', () => {
+      const { handleValidationError } = useErrorHandler()
 
-        handleValidationError({
-          issues: [{ msg: 'required' }]
-        })
+      handleValidationError({
+        issues: [{ msg: 'required' }]
+      })
 
-        expect(consoleSpy).toHaveBeenCalled()
-        const msg = consoleSpy.mock.calls[0][0] as string
-        expect(msg).toContain('Form validation')
-      }
-    )
+      expect(consoleSpy).toHaveBeenCalled()
+      const msg = consoleSpy.mock.calls[0][0] as string
+      expect(msg).toContain('Form validation')
+    })
   })
 
   describe('handleSilentError', () => {
@@ -277,18 +273,15 @@ describe('useErrorHandler', () => {
     })
 
     // Requires import.meta.dev=true in vitest config define
-    it(
-      'logs without default source label',
-      () => {
-        const { handleSilentError } = useErrorHandler()
+    it('logs without default source label', () => {
+      const { handleSilentError } = useErrorHandler()
 
-        handleSilentError(new Error('quiet'))
+      handleSilentError(new Error('quiet'))
 
-        expect(consoleSpy).toHaveBeenCalled()
-        const msg = consoleSpy.mock.calls[0][0] as string
-        expect(msg).toMatch(/^\[SYSTEM\] Error:/)
-        expect(msg).not.toContain(' in ')
-      }
-    )
+      expect(consoleSpy).toHaveBeenCalled()
+      const msg = consoleSpy.mock.calls[0][0] as string
+      expect(msg).toMatch(/^\[SYSTEM\] Error:/)
+      expect(msg).not.toContain(' in ')
+    })
   })
 })

--- a/tests/unit/composables/useCompanyEdit.test.ts
+++ b/tests/unit/composables/useCompanyEdit.test.ts
@@ -83,6 +83,17 @@ vi.mock('@vee-validate/zod', () => ({
 // Mock CompanyRepository
 vi.mock('~/composables/api/repositories/CompanyRepository')
 
+// Mock useErrorHandler to prevent real toast calls in error paths
+vi.mock('~/composables/errors/useErrorHandler', () => ({
+  useErrorHandler: () => ({
+    normalizeError: vi.fn((error: unknown) => error),
+    handleError: vi.fn((error: unknown) => error),
+    handleApiError: vi.fn((error: unknown) => error),
+    handleValidationError: vi.fn((error: unknown) => error),
+    handleSilentError: vi.fn((error: unknown) => error)
+  })
+}))
+
 describe('useCompanyEdit', () => {
   let authStore: ReturnType<typeof realUseAuthStore>
   let mockCompany: Company

--- a/tests/unit/composables/useHelp.test.ts
+++ b/tests/unit/composables/useHelp.test.ts
@@ -67,9 +67,7 @@ describe('useHelp', () => {
     mockPerformanceNow.mockReturnValue(100)
 
     // Reset modal mock
-    mockModal.onDidDismiss.mockReturnValue(
-      Promise.resolve({ data: undefined, role: undefined })
-    )
+    mockModal.onDidDismiss.mockReturnValue(Promise.resolve({ data: undefined, role: undefined }))
 
     // Mock window properties
     Object.defineProperty(window, 'pageYOffset', {
@@ -221,9 +219,7 @@ describe('useHelp', () => {
 
       mockModal.present.mockRejectedValueOnce(new Error('Present failed'))
 
-      await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow(
-        'Present failed'
-      )
+      await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow('Present failed')
     })
   })
 
@@ -333,7 +329,6 @@ describe('useHelp', () => {
 
       // Simulate modal dismiss
       dismissCallback({ data: undefined, role: 'backdrop' })
-
     })
 
     it('should restore scroll position on dismiss', async () => {

--- a/tests/unit/composables/useHelp.test.ts
+++ b/tests/unit/composables/useHelp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { nextTick } from 'vue'
 import { HelpTopic } from '../../../shared/types/help'
 
@@ -42,13 +42,6 @@ const mockPerformanceNow = vi.spyOn(performance, 'now')
 describe('useHelp', () => {
   let mockModalController: { create: ReturnType<typeof vi.fn> }
   let useHelp: typeof import('~/composables/useHelp').useHelp
-  let originalConsole: {
-    log: typeof console.log
-    warn: typeof console.warn
-    error: typeof console.error
-    debug: typeof console.debug
-  }
-
   beforeEach(async () => {
     vi.clearAllMocks()
 
@@ -73,22 +66,10 @@ describe('useHelp', () => {
 
     mockPerformanceNow.mockReturnValue(100)
 
-    // Store original console methods
-    originalConsole = {
-      log: console.log,
-      warn: console.warn,
-      error: console.error,
-      debug: console.debug
-    }
-
-    // Mock console methods
-    console.log = vi.fn()
-    console.warn = vi.fn()
-    console.error = vi.fn()
-    console.debug = vi.fn()
-
     // Reset modal mock
-    mockModal.onDidDismiss.mockReturnValue(Promise.resolve({ data: undefined, role: undefined }))
+    mockModal.onDidDismiss.mockReturnValue(
+      Promise.resolve({ data: undefined, role: undefined })
+    )
 
     // Mock window properties
     Object.defineProperty(window, 'pageYOffset', {
@@ -106,14 +87,6 @@ describe('useHelp', () => {
       writable: true,
       configurable: true
     })
-  })
-
-  afterEach(() => {
-    // Restore console methods
-    console.log = originalConsole.log
-    console.warn = originalConsole.warn
-    console.error = originalConsole.error
-    console.debug = originalConsole.debug
   })
 
   describe('Singleton pattern', () => {
@@ -139,9 +112,6 @@ describe('useHelp', () => {
 
       // Should not create a second modal
       expect(mockModalController.create).toHaveBeenCalledTimes(1)
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Modal already open, preventing duplicate'
-      )
 
       // Cleanup - simulate dismiss
       if (dismissResolve) {
@@ -205,15 +175,12 @@ describe('useHelp', () => {
       })
 
       expect(mockModal.present).toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledWith('[useHelp] Opening help modal', expect.any(Object))
     })
 
     it('should handle invalid topic', async () => {
       const { showHelp } = useHelp()
 
       await showHelp('invalid.topic' as HelpTopic)
-
-      expect(console.warn).toHaveBeenCalledWith('[useHelp] Invalid help topic:', 'invalid.topic')
 
       // Should still create modal but with null topic
       expect(mockModalController.create).toHaveBeenCalledWith(
@@ -230,8 +197,6 @@ describe('useHelp', () => {
 
       await showHelp(undefined)
 
-      expect(console.debug).toHaveBeenCalledWith('[useHelp] No topic provided')
-
       expect(mockModalController.create).toHaveBeenCalledWith(
         expect.objectContaining({
           componentProps: expect.objectContaining({
@@ -239,60 +204,6 @@ describe('useHelp', () => {
           })
         })
       )
-    })
-
-    it('should track performance metrics', async () => {
-      const { showHelp } = useHelp()
-
-      mockPerformanceNow.mockReturnValueOnce(100) // start
-      mockPerformanceNow.mockReturnValueOnce(150) // end
-
-      await showHelp(HelpTopic.GETTING_STARTED)
-
-      expect(console.log).toHaveBeenCalledWith(
-        '[useHelp] Modal presented successfully',
-        expect.objectContaining({
-          loadTime: '50.00ms'
-        })
-      )
-    })
-
-    it('should warn if modal takes too long to open', async () => {
-      const { showHelp } = useHelp()
-
-      mockPerformanceNow.mockReturnValueOnce(100) // start
-      mockPerformanceNow.mockReturnValueOnce(350) // end (250ms)
-
-      await showHelp(HelpTopic.GETTING_STARTED)
-
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Modal took longer than 200ms to open:',
-        '250.00ms'
-      )
-    })
-
-    it('should save scroll position', async () => {
-      const { showHelp } = useHelp()
-
-      window.pageYOffset = 500
-
-      await showHelp(HelpTopic.GETTING_STARTED)
-
-      expect(console.debug).toHaveBeenCalledWith('[useHelp] Saved scroll position:', 500)
-    })
-
-    it('should save focus element', async () => {
-      const { showHelp } = useHelp()
-
-      const mockElement = { tagName: 'INPUT', focus: vi.fn() }
-      Object.defineProperty(document, 'activeElement', {
-        value: mockElement,
-        configurable: true
-      })
-
-      await showHelp(HelpTopic.GETTING_STARTED)
-
-      expect(console.debug).toHaveBeenCalledWith('[useHelp] Saved focus element:', 'INPUT')
     })
 
     it('should handle modal creation error', async () => {
@@ -303,11 +214,6 @@ describe('useHelp', () => {
       await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow(
         'Unable to create help modal. Please try again.'
       )
-
-      expect(console.error).toHaveBeenCalledWith(
-        '[useHelp] Failed to create modal:',
-        expect.any(Error)
-      )
     })
 
     it('should handle modal present error', async () => {
@@ -315,11 +221,8 @@ describe('useHelp', () => {
 
       mockModal.present.mockRejectedValueOnce(new Error('Present failed'))
 
-      await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow('Present failed')
-
-      expect(console.error).toHaveBeenCalledWith(
-        '[useHelp] Error showing help modal:',
-        expect.any(Error)
+      await expect(showHelp(HelpTopic.GETTING_STARTED)).rejects.toThrow(
+        'Present failed'
       )
     })
   })
@@ -341,7 +244,6 @@ describe('useHelp', () => {
       await hideHelp()
 
       expect(mockModal.dismiss).toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledWith('[useHelp] Hiding help modal')
 
       // Cleanup
       if (dismissResolve) {
@@ -355,7 +257,6 @@ describe('useHelp', () => {
       await hideHelp()
 
       expect(mockModal.dismiss).not.toHaveBeenCalled()
-      expect(console.log).toHaveBeenCalledWith('[useHelp] No modal to hide')
     })
 
     it('should handle dismiss error gracefully', async () => {
@@ -374,11 +275,6 @@ describe('useHelp', () => {
 
       mockModal.dismiss.mockRejectedValueOnce(new Error('Dismiss failed'))
       await hideHelp()
-
-      expect(console.error).toHaveBeenCalledWith(
-        '[useHelp] Error hiding help modal:',
-        expect.any(Error)
-      )
 
       // Cleanup
       if (dismissResolve) {
@@ -438,7 +334,6 @@ describe('useHelp', () => {
       // Simulate modal dismiss
       dismissCallback({ data: undefined, role: 'backdrop' })
 
-      expect(console.log).toHaveBeenCalledWith('[useHelp] Modal dismissed', expect.any(Object))
     })
 
     it('should restore scroll position on dismiss', async () => {
@@ -465,7 +360,6 @@ describe('useHelp', () => {
       dismissCallback({ data: undefined, role: 'backdrop' })
 
       expect(scrollToSpy).toHaveBeenCalledWith(0, 500)
-      expect(console.debug).toHaveBeenCalledWith('[useHelp] Restored scroll position:', 500)
     })
 
     it('should restore focus on dismiss', async () => {
@@ -495,7 +389,6 @@ describe('useHelp', () => {
       dismissCallback({ data: undefined, role: 'backdrop' })
 
       expect(mockElement.focus).toHaveBeenCalled()
-      expect(console.debug).toHaveBeenCalledWith('[useHelp] Restored focus to:', 'INPUT')
     })
 
     it('should handle dismiss callback error', async () => {
@@ -518,11 +411,6 @@ describe('useHelp', () => {
 
       // Simulate error in dismiss handler
       catchCallback(new Error('Dismiss handler error'))
-
-      expect(console.error).toHaveBeenCalledWith(
-        '[useHelp] Error in dismiss handler:',
-        expect.any(Error)
-      )
     })
   })
 
@@ -547,8 +435,6 @@ describe('useHelp', () => {
 
       await nextTick()
 
-      expect(console.debug).toHaveBeenCalledWith('[useHelp] Escape key pressed, closing modal')
-
       // Cleanup
       if (dismissResolve) {
         dismissResolve({ data: undefined })
@@ -566,7 +452,8 @@ describe('useHelp', () => {
 
       await nextTick()
 
-      expect(console.debug).not.toHaveBeenCalledWith('[useHelp] Escape key pressed, closing modal')
+      // Modal dismiss should not be called for non-Escape keys
+      expect(mockModal.dismiss).not.toHaveBeenCalled()
     })
 
     it('should not close modal if no modal is open', async () => {
@@ -599,11 +486,6 @@ describe('useHelp', () => {
       })
 
       await showHelp(HelpTopic.GETTING_STARTED)
-
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Failed to save scroll position:',
-        expect.any(Error)
-      )
     })
 
     it('should handle focus save error', async () => {
@@ -618,11 +500,6 @@ describe('useHelp', () => {
       })
 
       await showHelp(HelpTopic.GETTING_STARTED)
-
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Failed to save focus:',
-        expect.any(Error)
-      )
     })
 
     it('should handle scroll restore error', async () => {
@@ -649,11 +526,6 @@ describe('useHelp', () => {
 
       await showHelp(HelpTopic.GETTING_STARTED)
       dismissCallback({ data: undefined })
-
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Failed to restore scroll position:',
-        expect.any(Error)
-      )
     })
 
     it('should handle focus restore error', async () => {
@@ -684,11 +556,6 @@ describe('useHelp', () => {
 
       await showHelp(HelpTopic.GETTING_STARTED)
       dismissCallback({ data: undefined })
-
-      expect(console.warn).toHaveBeenCalledWith(
-        '[useHelp] Failed to restore focus:',
-        expect.any(Error)
-      )
     })
   })
 })

--- a/tests/unit/composables/useUserRole.test.ts
+++ b/tests/unit/composables/useUserRole.test.ts
@@ -370,13 +370,9 @@ describe('useUserRole', () => {
       authStore.setUser({ _id: 'user1', id: 'user1', email: 'u@test.com' })
       authStore.setActiveCompany({ _id: 'comp1', id: 'comp1' })
 
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleWarnSpy).toHaveBeenCalledWith('[useUserRole] localStorage not available')
 
-      consoleWarnSpy.mockRestore()
       global.window = originalWindow
     })
 
@@ -386,16 +382,8 @@ describe('useUserRole', () => {
 
       mockStorage['auth_active_company_roles'] = '{ invalid json }'
 
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[useUserRole] Failed to parse role data:',
-        expect.any(Error)
-      )
-
-      consoleErrorSpy.mockRestore()
     })
 
     it('should handle missing role data', () => {
@@ -416,13 +404,8 @@ describe('useUserRole', () => {
         invalid: 'structure'
       })
 
-      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleWarnSpy).toHaveBeenCalledWith('[useUserRole] Invalid role data structure')
-
-      consoleWarnSpy.mockRestore()
     })
 
     it('should handle localStorage quota exceeded', () => {
@@ -443,13 +426,9 @@ describe('useUserRole', () => {
         clear: vi.fn()
       })
 
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleErrorSpy).toHaveBeenCalledWith('[useUserRole] localStorage quota exceeded')
 
-      consoleErrorSpy.mockRestore()
       // Restore original
       global.useStorage = () => ({
         get: originalGet,
@@ -475,13 +454,8 @@ describe('useUserRole', () => {
         clear: vi.fn()
       })
 
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
       const { hasAnyRole } = useUserRole()
       expect(hasAnyRole()).toBe(false)
-      expect(consoleErrorSpy).toHaveBeenCalledWith('[useUserRole] localStorage access denied')
-
-      consoleErrorSpy.mockRestore()
     })
 
     it('should clear corrupt data on parse error', () => {

--- a/tests/unit/stores/auth.test.ts
+++ b/tests/unit/stores/auth.test.ts
@@ -263,11 +263,8 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       await store.fetchProfile()
       expect(mockSwitchCompany).not.toHaveBeenCalled()
-      const errorMsg = '[AUTH] First company has no valid ID'
-      expect(consoleErrorSpy).toHaveBeenCalledWith(errorMsg)
       expect(store.activeCompany).toBeNull()
       const normalizedCompanies = profileWithInvalidId.other_companies.map(
         (c: { _id?: string; id?: string; name: string }) => {
@@ -277,7 +274,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         }
       )
       expect(store.otherCompanies).toEqual(normalizedCompanies)
-      consoleErrorSpy.mockRestore()
     })
   })
   describe('Retry mechanism', () => {
@@ -319,7 +315,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
       const fetchPromise = store.fetchProfile()
       await vi.runOnlyPendingTimersAsync()
       await vi.advanceTimersByTimeAsync(1000)
@@ -328,13 +323,11 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       await fetchPromise
       expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
       expect(mockSwitchCompany).toHaveBeenCalledWith('comp1')
-      expect(consoleLogSpy).toHaveBeenCalledWith('[AUTH] Successfully auto-selected company')
       expect(store.activeCompany).toEqual({
         _id: 'comp1',
         id: 'comp1',
         name: 'First Co'
       })
-      consoleLogSpy.mockRestore()
       vi.useRealTimers()
     })
     it('should fall back to local selection after all retries fail', async () => {
@@ -360,8 +353,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const fetchPromise = store.fetchProfile()
       await vi.runOnlyPendingTimersAsync()
       await vi.advanceTimersByTimeAsync(1000)
@@ -369,12 +360,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       await vi.advanceTimersByTimeAsync(1000)
       await fetchPromise
       expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[AUTH] Failed to auto-select company:',
-        expect.any(Error)
-      )
-      const fallbackMsg = '[AUTH] Using local fallback for company selection'
-      expect(consoleLogSpy).toHaveBeenCalledWith(fallbackMsg)
       expect(store.activeCompany).toEqual({
         _id: 'comp1',
         id: 'comp1',
@@ -392,8 +377,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         ...profileWithoutActiveCompany.user,
         id: profileWithoutActiveCompany.user._id
       })
-      consoleLogSpy.mockRestore()
-      consoleErrorSpy.mockRestore()
       vi.useRealTimers()
     })
     it('should use correct fixed retry delays', async () => {
@@ -416,8 +399,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
-      const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const fetchPromise = store.fetchProfile()
       await vi.runOnlyPendingTimersAsync()
       await vi.advanceTimersByTimeAsync(1000)
@@ -425,8 +406,6 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       await vi.advanceTimersByTimeAsync(1000)
       await fetchPromise
       expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
-      consoleLogSpy.mockRestore()
-      consoleErrorSpy.mockRestore()
       vi.useRealTimers()
     })
   })
@@ -583,13 +562,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: vi.fn()
       }))
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       await expect(store.fetchProfile()).rejects.toThrow('API Error')
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        '[AUTH] Failed to fetch profile:',
-        expect.any(Error)
-      )
-      consoleErrorSpy.mockRestore()
     })
     it('should handle edge case of empty other_companies array', async () => {
       const profile: ProfileResponse = {

--- a/tests/unit/utils/regex-validation.test.ts
+++ b/tests/unit/utils/regex-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { isValidRegex, createSafeRegex } from '../../../app/utils/helpers'
 
 describe('Regex Validation', () => {
@@ -20,16 +20,11 @@ describe('Regex Validation', () => {
     })
 
     it('detects ReDoS vulnerable patterns', () => {
-      const consoleSpy = vi.spyOn(console, 'warn')
-
       // Catastrophic backtracking patterns
       expect(isValidRegex('(a+)+')).toBe(false)
       expect(isValidRegex('(a*)+')).toBe(false)
       expect(isValidRegex('(.*+)+')).toBe(false)
       expect(isValidRegex('(\\w+{1,10})+')).toBe(false)
-
-      expect(consoleSpy).toHaveBeenCalled()
-      consoleSpy.mockRestore()
     })
 
     it('allows safe repetition patterns', () => {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -12,23 +12,11 @@ function nuxtMetaFlags() {
     name: 'nuxt-meta-flags',
     enforce: 'pre',
     transform(code, id) {
-      if (
-        id.includes('node_modules') ||
-        id.includes('/tests/')
-      ) return
-      if (
-        !code.includes('import.meta.dev') &&
-        !code.includes('import.meta.client')
-      ) return
+      if (id.includes('node_modules') || id.includes('/tests/')) return
+      if (!code.includes('import.meta.dev') && !code.includes('import.meta.client')) return
       return code
-        .replaceAll(
-          'import.meta.dev',
-          'import.meta.env?.DEV'
-        )
-        .replaceAll(
-          'import.meta.client',
-          '(!import.meta.env?.SSR)'
-        )
+        .replaceAll('import.meta.dev', 'import.meta.env?.DEV')
+        .replaceAll('import.meta.client', '(!import.meta.env?.SSR)')
     }
   }
 }
@@ -62,13 +50,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',
-      exclude: [
-        'node_modules/**',
-        'tests/**',
-        '**/*.config.*',
-        '.nuxt/**',
-        'dist/**'
-      ],
+      exclude: ['node_modules/**', 'tests/**', '**/*.config.*', '.nuxt/**', 'dist/**'],
       thresholds: {
         lines: 25,
         branches: 78,

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -2,6 +2,37 @@ import { defineConfig } from 'vitest/config'
 import path from 'node:path'
 import vue from '@vitejs/plugin-vue'
 
+/**
+ * Replace Nuxt-specific import.meta flags with standard
+ * Vite env equivalents so app code works under Vitest.
+ * Only transforms app source (skips node_modules/tests).
+ */
+function nuxtMetaFlags() {
+  return {
+    name: 'nuxt-meta-flags',
+    enforce: 'pre',
+    transform(code, id) {
+      if (
+        id.includes('node_modules') ||
+        id.includes('/tests/')
+      ) return
+      if (
+        !code.includes('import.meta.dev') &&
+        !code.includes('import.meta.client')
+      ) return
+      return code
+        .replaceAll(
+          'import.meta.dev',
+          'import.meta.env?.DEV'
+        )
+        .replaceAll(
+          'import.meta.client',
+          '(!import.meta.env?.SSR)'
+        )
+    }
+  }
+}
+
 export default defineConfig({
   plugins: [
     vue({
@@ -10,8 +41,10 @@ export default defineConfig({
           isCustomElement: tag => tag.startsWith('ion-')
         }
       }
-    })
+    }),
+    nuxtMetaFlags()
   ],
+  define: { 'import.meta.dev': true },
   test: {
     environment: 'jsdom',
     setupFiles: ['./tests/setup/test-setup.ts'],
@@ -29,7 +62,13 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['node_modules/**', 'tests/**', '**/*.config.*', '.nuxt/**', 'dist/**'],
+      exclude: [
+        'node_modules/**',
+        'tests/**',
+        '**/*.config.*',
+        '.nuxt/**',
+        'dist/**'
+      ],
       thresholds: {
         lines: 25,
         branches: 78,


### PR DESCRIPTION
## Summary

- Migrate all 88 `console.*` call sites across 30 files in `app/` to use `useErrorHandler` composable
- Add `import.meta.client` SSG safety guard on toast display in `useErrorHandler`
- Install `no-console: 'error'` ESLint rule scoped to `app/**/*.{ts,vue}`
- Add `errors.api.generic` and `errors.validation.generic` i18n keys to de-DE, es-ES, fr-FR, pt-BR
- Add 18-test unit spec for `useErrorHandler` with full line/branch coverage
- Add Vite plugin for `import.meta.dev`/`import.meta.client` transforms in Vitest

## Acceptance criteria verified

1. Composable surface unchanged
2. Toast only shown when `import.meta.client === true`
3. Only 3 sanctioned console sites remain (each with eslint-disable)
4. `npm run lint -- --max-warnings 153` passes
5. 18 unit tests pass for useErrorHandler
6. All 5 locale files have error keys
7. `npm run typecheck` and `npm run generate` succeed
8. `useLog.ts` duplicate console lines removed, `useHelp.ts` trace lines deleted

## Test plan

- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm run typecheck` — clean
- [x] `npx vitest run --pool=forks --maxWorkers=1` — 553 tests pass
- [x] `npm run generate` — SSG build succeeds
- [ ] Manual: trigger API error in dev → danger toast appears top
- [ ] Manual: switch to fr-FR, trigger error → French text in toast

Closes #24

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Centralized/silent error handling for more consistent runtime behavior while preserving user-facing error toasts and recovery flows.
  * Reduced noisy development logs so end-user flows aren’t affected by internal console output.

* **Localization**
  * Added localized generic API and form-validation error messages for German, Spanish, French, and Portuguese.

* **Code Quality**
  * Tightened linting and expanded test coverage to enforce consistent error-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->