### PR TITLE
refactor: finish useFormValidation adoption with i18n-aware schemas

### DIFF
--- a/app/components/auth/LoginForm.vue
+++ b/app/components/auth/LoginForm.vue
@@ -36,8 +36,14 @@
 </template>
 
 <script setup lang="ts">
-import type { LoginCredentials } from '../../../shared/types'
-import { loginSchema, useFormValidation } from '~/composables/validation/useFormValidation'
+import { useI18n } from 'vue-i18n'
+import type {
+  LoginCredentials,
+} from '../../../shared/types'
+import {
+  createLoginSchema,
+  useFormValidation,
+} from '~/composables/validation/useFormValidation'
 
 interface Props {
   loading?: boolean
@@ -55,9 +61,16 @@ withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
-const { handleSubmit, defineField, errors, isValid } = useFormValidation(loginSchema, {
+const { t } = useI18n()
+const schema = createLoginSchema(t)
+const {
+  handleSubmit,
+  defineField,
+  errors,
+  isValid,
+} = useFormValidation(schema, {
   email: '',
-  password: ''
+  password: '',
 })
 
 const [email] = defineField('email' as const)

--- a/app/components/auth/LoginForm.vue
+++ b/app/components/auth/LoginForm.vue
@@ -37,13 +37,8 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import type {
-  LoginCredentials,
-} from '../../../shared/types'
-import {
-  createLoginSchema,
-  useFormValidation,
-} from '~/composables/validation/useFormValidation'
+import type { LoginCredentials } from '../../../shared/types'
+import { createLoginSchema, useFormValidation } from '~/composables/validation/useFormValidation'
 
 interface Props {
   loading?: boolean
@@ -63,14 +58,9 @@ const emit = defineEmits<Emits>()
 
 const { t } = useI18n()
 const schema = createLoginSchema(t)
-const {
-  handleSubmit,
-  defineField,
-  errors,
-  isValid,
-} = useFormValidation(schema, {
+const { handleSubmit, defineField, errors, isValid } = useFormValidation(schema, {
   email: '',
-  password: '',
+  password: ''
 })
 
 const [email] = defineField('email' as const)

--- a/app/components/auth/RegisterForm.vue
+++ b/app/components/auth/RegisterForm.vue
@@ -10,10 +10,7 @@
         :placeholder="$t('auth.enterEmail')"
         :disabled="submitting"
       />
-      <ion-note
-        v-if="errors.email"
-        color="danger"
-      >
+      <ion-note v-if="errors.email" color="danger">
         {{ errors.email }}
       </ion-note>
     </ion-item>
@@ -28,10 +25,7 @@
         :placeholder="$t('auth.enterPassword')"
         :disabled="submitting"
       />
-      <ion-note
-        v-if="errors.password"
-        color="danger"
-      >
+      <ion-note v-if="errors.password" color="danger">
         {{ errors.password }}
       </ion-note>
     </ion-item>
@@ -43,21 +37,14 @@
         :disabled="submitting || !isValid"
         class="ion-margin-top"
       >
-        <ion-spinner
-          v-if="submitting"
-          name="crescent"
-        />
+        <ion-spinner v-if="submitting" name="crescent" />
         <span v-else>
           {{ $t('auth.registerButton') }}
         </span>
       </ion-button>
     </div>
 
-    <ion-text
-      v-if="error"
-      color="danger"
-      class="ion-margin-top"
-    >
+    <ion-text v-if="error" color="danger" class="ion-margin-top">
       <p>{{ error }}</p>
     </ion-text>
   </form>
@@ -67,7 +54,7 @@
 import { useI18n } from 'vue-i18n'
 import {
   createRegisterEmailPasswordSchema,
-  useFormValidation,
+  useFormValidation
 } from '~/composables/validation/useFormValidation'
 
 interface Props {
@@ -76,14 +63,12 @@ interface Props {
 }
 
 interface Emits {
-  submit: [
-    formData: { email: string; password: string },
-  ]
+  submit: [formData: { email: string; password: string }]
 }
 
 withDefaults(defineProps<Props>(), {
   submitting: false,
-  error: '',
+  error: ''
 })
 
 const emit = defineEmits<Emits>()
@@ -94,10 +79,10 @@ const {
   handleSubmit: formSubmit,
   defineField,
   errors,
-  isValid,
+  isValid
 } = useFormValidation(schema, {
   email: '',
-  password: '',
+  password: ''
 })
 
 const [email] = defineField('email' as const)
@@ -106,7 +91,7 @@ const [password] = defineField('password' as const)
 const onSubmit = formSubmit(values => {
   emit('submit', {
     email: values.email as string,
-    password: values.password as string,
+    password: values.password as string
   })
 })
 </script>

--- a/app/components/auth/RegisterForm.vue
+++ b/app/components/auth/RegisterForm.vue
@@ -1,67 +1,112 @@
 <template>
-  <form @submit.prevent="handleSubmit">
+  <form @submit.prevent="onSubmit">
     <ion-item>
-      <ion-label position="stacked">{{ $t('auth.email') }}</ion-label>
+      <ion-label position="stacked">
+        {{ $t('auth.email') }}
+      </ion-label>
       <ion-input
         v-model="email"
         type="email"
         :placeholder="$t('auth.enterEmail')"
-        required
         :disabled="submitting"
       />
+      <ion-note
+        v-if="errors.email"
+        color="danger"
+      >
+        {{ errors.email }}
+      </ion-note>
     </ion-item>
 
     <ion-item>
-      <ion-label position="stacked">{{ $t('auth.password') }}</ion-label>
+      <ion-label position="stacked">
+        {{ $t('auth.password') }}
+      </ion-label>
       <ion-input
         v-model="password"
         type="password"
         :placeholder="$t('auth.enterPassword')"
-        required
         :disabled="submitting"
       />
+      <ion-note
+        v-if="errors.password"
+        color="danger"
+      >
+        {{ errors.password }}
+      </ion-note>
     </ion-item>
 
     <div class="button-container">
       <ion-button
         expand="block"
         type="submit"
-        :disabled="submitting || !email || !password"
+        :disabled="submitting || !isValid"
         class="ion-margin-top"
       >
-        <ion-spinner v-if="submitting" name="crescent" />
-        <span v-else>{{ $t('auth.registerButton') }}</span>
+        <ion-spinner
+          v-if="submitting"
+          name="crescent"
+        />
+        <span v-else>
+          {{ $t('auth.registerButton') }}
+        </span>
       </ion-button>
     </div>
 
-    <ion-text v-if="error" color="danger" class="ion-margin-top">
+    <ion-text
+      v-if="error"
+      color="danger"
+      class="ion-margin-top"
+    >
       <p>{{ error }}</p>
     </ion-text>
   </form>
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import {
+  createRegisterEmailPasswordSchema,
+  useFormValidation,
+} from '~/composables/validation/useFormValidation'
+
 interface Props {
   submitting?: boolean
   error?: string
 }
 
 interface Emits {
-  submit: [formData: { email: string; password: string }]
+  submit: [
+    formData: { email: string; password: string },
+  ]
 }
 
 withDefaults(defineProps<Props>(), {
   submitting: false,
-  error: ''
+  error: '',
 })
 
 const emit = defineEmits<Emits>()
 
-const email = ref('')
-const password = ref('')
+const { t } = useI18n()
+const schema = createRegisterEmailPasswordSchema(t)
+const {
+  handleSubmit: formSubmit,
+  defineField,
+  errors,
+  isValid,
+} = useFormValidation(schema, {
+  email: '',
+  password: '',
+})
 
-const handleSubmit = () => {
-  if (!email.value || !password.value) return
-  emit('submit', { email: email.value, password: password.value })
-}
+const [email] = defineField('email' as const)
+const [password] = defineField('password' as const)
+
+const onSubmit = formSubmit(values => {
+  emit('submit', {
+    email: values.email as string,
+    password: values.password as string,
+  })
+})
 </script>

--- a/app/composables/useCompanyEdit.ts
+++ b/app/composables/useCompanyEdit.ts
@@ -1,12 +1,8 @@
 import { useI18n } from 'vue-i18n'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'
-import {
-  createCompanyEditSchema,
-} from '~/composables/validation/useFormValidation'
-import type {
-  CompanyEditForm,
-} from '~/composables/validation/useFormValidation'
+import { createCompanyEditSchema } from '~/composables/validation/useFormValidation'
+import type { CompanyEditForm } from '~/composables/validation/useFormValidation'
 import { CompanyRepository } from './api/repositories/CompanyRepository'
 import type { UpdateCompanyRequest } from './api/repositories/CompanyRepository'
 import { useErrorHandler } from './errors/useErrorHandler'

--- a/app/composables/useCompanyEdit.ts
+++ b/app/composables/useCompanyEdit.ts
@@ -1,8 +1,12 @@
 import { useI18n } from 'vue-i18n'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'
-import { createCompanyEditSchema } from '~/utils/validation/companySchemas'
-import type { CompanyEditForm } from '~/utils/validation/companySchemas'
+import {
+  createCompanyEditSchema,
+} from '~/composables/validation/useFormValidation'
+import type {
+  CompanyEditForm,
+} from '~/composables/validation/useFormValidation'
 import { CompanyRepository } from './api/repositories/CompanyRepository'
 import type { UpdateCompanyRequest } from './api/repositories/CompanyRepository'
 import { useErrorHandler } from './errors/useErrorHandler'

--- a/app/composables/useProfileEdit.ts
+++ b/app/composables/useProfileEdit.ts
@@ -1,16 +1,10 @@
 import { useI18n } from 'vue-i18n'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'
-import {
-  createProfileEditSchema,
-} from '~/composables/validation/useFormValidation'
+import { createProfileEditSchema } from '~/composables/validation/useFormValidation'
 import { UserService } from './api/services/UserService'
-import type {
-  UpdateUserRequest,
-} from '../../shared/types'
-import {
-  useErrorHandler,
-} from './errors/useErrorHandler'
+import type { UpdateUserRequest } from '../../shared/types'
+import { useErrorHandler } from './errors/useErrorHandler'
 
 export type ProfileEditForm = {
   name: string

--- a/app/composables/useProfileEdit.ts
+++ b/app/composables/useProfileEdit.ts
@@ -1,10 +1,16 @@
 import { useI18n } from 'vue-i18n'
-import { z } from 'zod'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm, useField } from 'vee-validate'
+import {
+  createProfileEditSchema,
+} from '~/composables/validation/useFormValidation'
 import { UserService } from './api/services/UserService'
-import type { UpdateUserRequest } from '../../shared/types'
-import { useErrorHandler } from './errors/useErrorHandler'
+import type {
+  UpdateUserRequest,
+} from '../../shared/types'
+import {
+  useErrorHandler,
+} from './errors/useErrorHandler'
 
 export type ProfileEditForm = {
   name: string
@@ -18,11 +24,7 @@ export const useProfileEdit = () => {
   const userService = new UserService()
   const { handleSilentError } = useErrorHandler()
 
-  const profileEditSchema = z.object({
-    name: z.string().min(1, t('validation.profile.nameRequired')),
-    city: z.string().optional(),
-    country: z.string().optional()
-  })
+  const profileEditSchema = createProfileEditSchema(t)
 
   // Edit state
   const isEditing = ref(false)

--- a/app/composables/validation/useFormValidation.ts
+++ b/app/composables/validation/useFormValidation.ts
@@ -3,32 +3,26 @@ import type { ZodSchema } from 'zod'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm } from 'vee-validate'
 
-export type TranslateFn = (
-  key: string,
-  params?: Record<string, unknown>
-) => string
+export type TranslateFn = (key: string, params?: Record<string, unknown>) => string
 
 export type MessageTree = Record<string, unknown>
 
 const fallbackMessages: MessageTree = {
   validation: {
     invalidEmail: 'Please enter a valid email address',
-    minLength:
-      'Password must be at least {min} characters',
+    minLength: 'Minimum length is {min} characters',
     required: 'This field is required',
-    invalidPhone:
-      'Please enter a valid phone number',
+    invalidPhone: 'Please enter a valid phone number',
     invalidUrl: 'Please enter a valid URL',
     passwordMatch: "Passwords don't match",
     profile: {
-      nameRequired: 'Name is required',
+      nameRequired: 'Name is required'
     },
     company: {
       nameRequired: 'Company name is required',
-      countryFormat:
-        'Country must be a 2-letter ISO code (e.g., FI)',
-    },
-  },
+      countryFormat: 'Country must be a 2-letter ISO code (e.g., FI)'
+    }
+  }
 }
 
 const resolveMessage = (
@@ -39,28 +33,17 @@ const resolveMessage = (
   let current: unknown = source
 
   for (const segment of segments) {
-    if (
-      current
-      && typeof current === 'object'
-      && segment in current
-    ) {
-      current = (
-        current as Record<string, unknown>
-      )[segment]
+    if (current && typeof current === 'object' && segment in current) {
+      current = (current as Record<string, unknown>)[segment]
     } else {
       return undefined
     }
   }
 
-  return typeof current === 'string'
-    ? current
-    : undefined
+  return typeof current === 'string' ? current : undefined
 }
 
-const interpolate = (
-  message: string,
-  params?: Record<string, unknown>
-): string => {
+const interpolate = (message: string, params?: Record<string, unknown>): string => {
   if (!params) return message
 
   return message.replace(/\{(\w+)\}/g, (_, param) => {
@@ -69,9 +52,7 @@ const interpolate = (
   })
 }
 
-export const createFallbackTranslator = (
-  source: MessageTree = fallbackMessages
-): TranslateFn => {
+export const createFallbackTranslator = (source: MessageTree = fallbackMessages): TranslateFn => {
   return (key, params) => {
     const msg = resolveMessage(key, source)
     if (!msg) return key
@@ -79,123 +60,76 @@ export const createFallbackTranslator = (
   }
 }
 
-const createValidationFragments = (
-  t: TranslateFn
-) => ({
-  email: z
-    .string()
-    .email(t('validation.invalidEmail')),
-  password: z
-    .string()
-    .min(8, t('validation.minLength', { min: 8 })),
-  required: z
-    .string()
-    .min(1, t('validation.required')),
-  phone: z
-    .string()
-    .regex(
-      /^\+?[\d\s\-()]+$/,
-      t('validation.invalidPhone')
-    ),
-  url: z.string().url(t('validation.invalidUrl')),
+const createValidationFragments = (t: TranslateFn) => ({
+  email: z.string().email(t('validation.invalidEmail')),
+  password: z.string().min(8, t('validation.minLength', { min: 8 })),
+  required: z.string().min(1, t('validation.required')),
+  phone: z.string().regex(/^\+?[\d\s\-()]+$/, t('validation.invalidPhone')),
+  url: z.string().url(t('validation.invalidUrl'))
 })
 
-export const validationSchemas =
-  createValidationFragments(createFallbackTranslator())
+export const validationSchemas = createValidationFragments(createFallbackTranslator())
 
-export const createLoginSchema = (
-  t: TranslateFn
-) => {
+export const createLoginSchema = (t: TranslateFn) => {
   const f = createValidationFragments(t)
   return z.object({
     email: f.email,
-    password: f.password,
+    password: f.password
   })
 }
 
-export const createRegisterSchema = (
-  t: TranslateFn
-) => {
+export const createRegisterSchema = (t: TranslateFn) => {
   const f = createValidationFragments(t)
   return z
     .object({
       name: f.required,
       email: f.email,
       password: f.password,
-      confirmPassword: f.password,
+      confirmPassword: f.password
     })
-    .refine(
-      data => data.password === data.confirmPassword,
-      {
-        message: t('validation.passwordMatch'),
-        path: ['confirmPassword'],
-      }
-    )
+    .refine(data => data.password === data.confirmPassword, {
+      message: t('validation.passwordMatch'),
+      path: ['confirmPassword']
+    })
 }
 
-export const createProfileSchema = (
-  t: TranslateFn
-) => {
+export const createProfileSchema = (t: TranslateFn) => {
   const f = createValidationFragments(t)
   return z.object({
     name: f.required,
     email: f.email,
     phone: f.phone.optional(),
-    website: f.url.optional(),
+    website: f.url.optional()
   })
 }
 
-export const createRegisterEmailPasswordSchema = (
-  t: TranslateFn
-) => {
+export const createRegisterEmailPasswordSchema = (t: TranslateFn) => {
   const f = createValidationFragments(t)
   return z.object({
     email: f.email,
-    password: f.password,
+    password: f.password
   })
 }
 
-export const createProfileEditSchema = (
-  t: TranslateFn
-) =>
+export const createProfileEditSchema = (t: TranslateFn) =>
   z.object({
-    name: z
-      .string()
-      .min(
-        1,
-        t('validation.profile.nameRequired')
-      ),
+    name: z.string().min(1, t('validation.profile.nameRequired')),
     city: z.string().optional(),
-    country: z.string().optional(),
+    country: z.string().optional()
   })
 
-export const createCompanyEditSchema = (
-  t: TranslateFn
-) =>
+export const createCompanyEditSchema = (t: TranslateFn) =>
   z.object({
-    name: z
-      .string()
-      .min(
-        1,
-        t('validation.company.nameRequired')
-      )
-      .max(200)
-      .optional(),
+    name: z.string().min(1, t('validation.company.nameRequired')).max(200).optional(),
     street: z.string().max(200).optional(),
     city: z.string().max(100).optional(),
     country: z
       .string()
-      .length(
-        2,
-        t('validation.company.countryFormat')
-      )
-      .regex(
-        /^[A-Z]{2}$/,
-        t('validation.company.countryFormat')
-      )
+      .length(2, t('validation.company.countryFormat'))
+      .regex(/^[A-Z]{2}$/, t('validation.company.countryFormat'))
       .optional(),
     timezone: z.string().optional(),
-    business_id: z.string().max(50).optional(),
+    business_id: z.string().max(50).optional()
   })
 
 export type CompanyEditForm = {
@@ -209,38 +143,24 @@ export type CompanyEditForm = {
 
 const fallbackT = createFallbackTranslator()
 
-export const loginSchema = toTypedSchema(
-  createLoginSchema(fallbackT)
+export const loginSchema = toTypedSchema(createLoginSchema(fallbackT))
+
+export const registerSchema = toTypedSchema(createRegisterSchema(fallbackT))
+
+export const profileSchema = toTypedSchema(createProfileSchema(fallbackT))
+
+export const registerEmailPasswordSchema = toTypedSchema(
+  createRegisterEmailPasswordSchema(fallbackT)
 )
 
-export const registerSchema = toTypedSchema(
-  createRegisterSchema(fallbackT)
-)
-
-export const profileSchema = toTypedSchema(
-  createProfileSchema(fallbackT)
-)
-
-export const registerEmailPasswordSchema =
-  toTypedSchema(
-    createRegisterEmailPasswordSchema(fallbackT)
-  )
-
-export function useFormValidation<
-  T extends Record<string, unknown>,
->(
-  schema:
-    | ZodSchema<T>
-    | ReturnType<typeof toTypedSchema>,
+export function useFormValidation<T extends Record<string, unknown>>(
+  schema: ZodSchema<T> | ReturnType<typeof toTypedSchema>,
   initialValues?: Partial<T>
 ) {
   const form = useForm<T>({
-    validationSchema:
-      schema instanceof z.ZodType
-        ? toTypedSchema(schema)
-        : schema,
+    validationSchema: schema instanceof z.ZodType ? toTypedSchema(schema) : schema,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    initialValues: initialValues as any,
+    initialValues: initialValues as any
   })
 
   return {
@@ -248,12 +168,10 @@ export function useFormValidation<
     isValid: computed(() => form.meta.value.valid),
     allErrors: computed(() => {
       const errors: string[] = []
-      Object.values(form.errors.value).forEach(
-        (error) => {
-          if (error) errors.push(error)
-        }
-      )
+      Object.values(form.errors.value).forEach(error => {
+        if (error) errors.push(error)
+      })
       return errors
-    }),
+    })
   }
 }

--- a/app/composables/validation/useFormValidation.ts
+++ b/app/composables/validation/useFormValidation.ts
@@ -3,69 +3,257 @@ import type { ZodSchema } from 'zod'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useForm } from 'vee-validate'
 
-// Common validation schemas
-export const validationSchemas = {
-  email: z.string().email('Please enter a valid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
-  required: z.string().min(1, 'This field is required'),
-  phone: z.string().regex(/^\+?[\d\s\-()]+$/, 'Please enter a valid phone number'),
-  url: z.string().url('Please enter a valid URL')
+export type TranslateFn = (
+  key: string,
+  params?: Record<string, unknown>
+) => string
+
+export type MessageTree = Record<string, unknown>
+
+const fallbackMessages: MessageTree = {
+  validation: {
+    invalidEmail: 'Please enter a valid email address',
+    minLength:
+      'Password must be at least {min} characters',
+    required: 'This field is required',
+    invalidPhone:
+      'Please enter a valid phone number',
+    invalidUrl: 'Please enter a valid URL',
+    passwordMatch: "Passwords don't match",
+    profile: {
+      nameRequired: 'Name is required',
+    },
+    company: {
+      nameRequired: 'Company name is required',
+      countryFormat:
+        'Country must be a 2-letter ISO code (e.g., FI)',
+    },
+  },
 }
 
-// Auth form schemas
-export const loginSchema = toTypedSchema(
-  z.object({
-    email: validationSchemas.email,
-    password: validationSchemas.password
+const resolveMessage = (
+  key: string,
+  source: MessageTree = fallbackMessages
+): string | undefined => {
+  const segments = key.split('.')
+  let current: unknown = source
+
+  for (const segment of segments) {
+    if (
+      current
+      && typeof current === 'object'
+      && segment in current
+    ) {
+      current = (
+        current as Record<string, unknown>
+      )[segment]
+    } else {
+      return undefined
+    }
+  }
+
+  return typeof current === 'string'
+    ? current
+    : undefined
+}
+
+const interpolate = (
+  message: string,
+  params?: Record<string, unknown>
+): string => {
+  if (!params) return message
+
+  return message.replace(/\{(\w+)\}/g, (_, param) => {
+    const value = params[param]
+    return value != null ? String(value) : ''
   })
+}
+
+export const createFallbackTranslator = (
+  source: MessageTree = fallbackMessages
+): TranslateFn => {
+  return (key, params) => {
+    const msg = resolveMessage(key, source)
+    if (!msg) return key
+    return interpolate(msg, params)
+  }
+}
+
+const createValidationFragments = (
+  t: TranslateFn
+) => ({
+  email: z
+    .string()
+    .email(t('validation.invalidEmail')),
+  password: z
+    .string()
+    .min(8, t('validation.minLength', { min: 8 })),
+  required: z
+    .string()
+    .min(1, t('validation.required')),
+  phone: z
+    .string()
+    .regex(
+      /^\+?[\d\s\-()]+$/,
+      t('validation.invalidPhone')
+    ),
+  url: z.string().url(t('validation.invalidUrl')),
+})
+
+export const validationSchemas =
+  createValidationFragments(createFallbackTranslator())
+
+export const createLoginSchema = (
+  t: TranslateFn
+) => {
+  const f = createValidationFragments(t)
+  return z.object({
+    email: f.email,
+    password: f.password,
+  })
+}
+
+export const createRegisterSchema = (
+  t: TranslateFn
+) => {
+  const f = createValidationFragments(t)
+  return z
+    .object({
+      name: f.required,
+      email: f.email,
+      password: f.password,
+      confirmPassword: f.password,
+    })
+    .refine(
+      data => data.password === data.confirmPassword,
+      {
+        message: t('validation.passwordMatch'),
+        path: ['confirmPassword'],
+      }
+    )
+}
+
+export const createProfileSchema = (
+  t: TranslateFn
+) => {
+  const f = createValidationFragments(t)
+  return z.object({
+    name: f.required,
+    email: f.email,
+    phone: f.phone.optional(),
+    website: f.url.optional(),
+  })
+}
+
+export const createRegisterEmailPasswordSchema = (
+  t: TranslateFn
+) => {
+  const f = createValidationFragments(t)
+  return z.object({
+    email: f.email,
+    password: f.password,
+  })
+}
+
+export const createProfileEditSchema = (
+  t: TranslateFn
+) =>
+  z.object({
+    name: z
+      .string()
+      .min(
+        1,
+        t('validation.profile.nameRequired')
+      ),
+    city: z.string().optional(),
+    country: z.string().optional(),
+  })
+
+export const createCompanyEditSchema = (
+  t: TranslateFn
+) =>
+  z.object({
+    name: z
+      .string()
+      .min(
+        1,
+        t('validation.company.nameRequired')
+      )
+      .max(200)
+      .optional(),
+    street: z.string().max(200).optional(),
+    city: z.string().max(100).optional(),
+    country: z
+      .string()
+      .length(
+        2,
+        t('validation.company.countryFormat')
+      )
+      .regex(
+        /^[A-Z]{2}$/,
+        t('validation.company.countryFormat')
+      )
+      .optional(),
+    timezone: z.string().optional(),
+    business_id: z.string().max(50).optional(),
+  })
+
+export type CompanyEditForm = {
+  name?: string
+  street?: string
+  city?: string
+  country?: string
+  timezone?: string
+  business_id?: string
+}
+
+const fallbackT = createFallbackTranslator()
+
+export const loginSchema = toTypedSchema(
+  createLoginSchema(fallbackT)
 )
 
 export const registerSchema = toTypedSchema(
-  z
-    .object({
-      name: validationSchemas.required,
-      email: validationSchemas.email,
-      password: validationSchemas.password,
-      confirmPassword: validationSchemas.password
-    })
-    .refine(data => data.password === data.confirmPassword, {
-      message: "Passwords don't match",
-      path: ['confirmPassword']
-    })
+  createRegisterSchema(fallbackT)
 )
 
-// Profile form schema
 export const profileSchema = toTypedSchema(
-  z.object({
-    name: validationSchemas.required,
-    email: validationSchemas.email,
-    phone: validationSchemas.phone.optional(),
-    website: validationSchemas.url.optional()
-  })
+  createProfileSchema(fallbackT)
 )
 
-// Generic form validation composable
-export function useFormValidation<T extends Record<string, unknown>>(
-  schema: ZodSchema<T> | ReturnType<typeof toTypedSchema>,
+export const registerEmailPasswordSchema =
+  toTypedSchema(
+    createRegisterEmailPasswordSchema(fallbackT)
+  )
+
+export function useFormValidation<
+  T extends Record<string, unknown>,
+>(
+  schema:
+    | ZodSchema<T>
+    | ReturnType<typeof toTypedSchema>,
   initialValues?: Partial<T>
 ) {
   const form = useForm<T>({
-    validationSchema: schema instanceof z.ZodType ? toTypedSchema(schema) : schema,
+    validationSchema:
+      schema instanceof z.ZodType
+        ? toTypedSchema(schema)
+        : schema,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    initialValues: initialValues as any
+    initialValues: initialValues as any,
   })
 
   return {
     ...form,
-    // Helper to check if form is valid and ready to submit
     isValid: computed(() => form.meta.value.valid),
-    // Helper to get all errors
     allErrors: computed(() => {
       const errors: string[] = []
-      Object.values(form.errors.value).forEach(error => {
-        if (error) errors.push(error)
-      })
+      Object.values(form.errors.value).forEach(
+        (error) => {
+          if (error) errors.push(error)
+        }
+      )
       return errors
-    })
+    }),
   }
 }

--- a/app/utils/validation/companySchemas.ts
+++ b/app/utils/validation/companySchemas.ts
@@ -1,7 +1,3 @@
-export {
-  createCompanyEditSchema,
-} from '~/composables/validation/useFormValidation'
+export { createCompanyEditSchema } from '~/composables/validation/useFormValidation'
 
-export type {
-  CompanyEditForm,
-} from '~/composables/validation/useFormValidation'
+export type { CompanyEditForm } from '~/composables/validation/useFormValidation'

--- a/app/utils/validation/companySchemas.ts
+++ b/app/utils/validation/companySchemas.ts
@@ -1,24 +1,7 @@
-import { z } from 'zod'
+export {
+  createCompanyEditSchema,
+} from '~/composables/validation/useFormValidation'
 
-export const createCompanyEditSchema = (t: (key: string) => string) =>
-  z.object({
-    name: z.string().min(1, t('validation.company.nameRequired')).max(200).optional(),
-    street: z.string().max(200).optional(),
-    city: z.string().max(100).optional(),
-    country: z
-      .string()
-      .length(2, t('validation.company.countryFormat'))
-      .regex(/^[A-Z]{2}$/, t('validation.company.countryFormat'))
-      .optional(),
-    timezone: z.string().optional(),
-    business_id: z.string().max(50).optional()
-  })
-
-export type CompanyEditForm = {
-  name?: string
-  street?: string
-  city?: string
-  country?: string
-  timezone?: string
-  business_id?: string
-}
+export type {
+  CompanyEditForm,
+} from '~/composables/validation/useFormValidation'

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -222,16 +222,16 @@ Pre-built English-default exports (`loginSchema`,
 
 From `i18n/locales/en-US.json`:
 
-| Key | English Value |
-|-----|---------------|
-| `validation.required` | This field is required |
-| `validation.invalidEmail` | Please enter a valid email address |
-| `validation.minLength` | Minimum length is {min} characters |
-| `validation.maxLength` | Maximum length is {max} characters |
-| `validation.passwordMatch` | Passwords don't match |
-| `validation.invalidFormat` | Invalid format |
-| `validation.profile.nameRequired` | Name is required |
-| `validation.company.nameRequired` | Company name is required |
+| Key                                | English Value                       |
+| ---------------------------------- | ----------------------------------- |
+| `validation.required`              | This field is required              |
+| `validation.invalidEmail`          | Please enter a valid email address  |
+| `validation.minLength`             | Minimum length is {min} characters  |
+| `validation.maxLength`             | Maximum length is {max} characters  |
+| `validation.passwordMatch`         | Passwords don't match               |
+| `validation.invalidFormat`         | Invalid format                      |
+| `validation.profile.nameRequired`  | Name is required                    |
+| `validation.company.nameRequired`  | Company name is required            |
 | `validation.company.countryFormat` | Country must be a 2-letter ISO code |
 
 ### Rules
@@ -242,7 +242,7 @@ From `i18n/locales/en-US.json`:
   fallback in `fallbackMessages` inside
   `useFormValidation.ts`.
 - Components call `createXSchema(t)` inside `<script
-  setup>` where `t` comes from `useI18n()`.
+setup>` where `t` comes from `useI18n()`.
 
 ## 8. Future Extensions
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -201,7 +201,50 @@ cp .env.example .env
 - Help modal accessibility: focus management and topic fallbacks.
 - Metrics/log instrumentation: ensure non-blocking behaviour and correct payload enrichment.
 
-## 7. Future Extensions
+## 7. Form Validation Conventions
+
+### Factory Pattern
+
+All form schemas live in
+`app/composables/validation/useFormValidation.ts` as
+factory functions that accept a translator:
+
+```ts
+const schema = createLoginSchema(t)
+```
+
+Pre-built English-default exports (`loginSchema`,
+`registerSchema`, `profileSchema`,
+`registerEmailPasswordSchema`) use
+`createFallbackTranslator()` for test compatibility.
+
+### Canonical i18n Keys
+
+From `i18n/locales/en-US.json`:
+
+| Key | English Value |
+|-----|---------------|
+| `validation.required` | This field is required |
+| `validation.invalidEmail` | Please enter a valid email address |
+| `validation.minLength` | Minimum length is {min} characters |
+| `validation.maxLength` | Maximum length is {max} characters |
+| `validation.passwordMatch` | Passwords don't match |
+| `validation.invalidFormat` | Invalid format |
+| `validation.profile.nameRequired` | Name is required |
+| `validation.company.nameRequired` | Company name is required |
+| `validation.company.countryFormat` | Country must be a 2-letter ISO code |
+
+### Rules
+
+- Schemas call factory functions, never `useI18n()` at
+  module top level.
+- Any new validation key must also have an English
+  fallback in `fallbackMessages` inside
+  `useFormValidation.ts`.
+- Components call `createXSchema(t)` inside `<script
+  setup>` where `t` comes from `useI18n()`.
+
+## 8. Future Extensions
 
 - Build authenticated video catalogue with purchase flows and progress tracking.
 - Add individual video detail pages with credit-based purchase using

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -308,7 +308,9 @@
     "company": {
       "nameRequired": "Firmenname ist erforderlich",
       "countryFormat": "Land muss ISO-Code mit 2 Buchstaben sein (z.B. DE)"
-    }
+    },
+    "invalidPhone": "Bitte geben Sie eine gültige Telefonnummer ein",
+    "invalidUrl": "Bitte geben Sie eine gültige URL ein"
   },
   "settings": {
     "title": "Einstellungen",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -327,7 +327,9 @@
     "company": {
       "nameRequired": "Company name is required",
       "countryFormat": "Country must be a 2-letter ISO code (e.g., FI)"
-    }
+    },
+    "invalidPhone": "Please enter a valid phone number",
+    "invalidUrl": "Please enter a valid URL"
   },
   "settings": {
     "title": "Settings",

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -310,7 +310,9 @@
     "company": {
       "nameRequired": "El nombre de la empresa es obligatorio",
       "countryFormat": "País debe ser código ISO de 2 letras (ej. ES)"
-    }
+    },
+    "invalidPhone": "Por favor ingresa un número de teléfono válido",
+    "invalidUrl": "Por favor ingresa una URL válida"
   },
   "settings": {
     "title": "Configuración",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -308,7 +308,9 @@
     "company": {
       "nameRequired": "Le nom de l'entreprise est obligatoire",
       "countryFormat": "Pays doit être code ISO 2 lettres (ex. FR)"
-    }
+    },
+    "invalidPhone": "Veuillez entrer un numéro de téléphone valide",
+    "invalidUrl": "Veuillez entrer une URL valide"
   },
   "settings": {
     "title": "Paramètres",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -308,7 +308,9 @@
     "company": {
       "nameRequired": "O nome da empresa é obrigatório",
       "countryFormat": "País deve ser código ISO de 2 letras (ex. BR)"
-    }
+    },
+    "invalidPhone": "Por favor, insira um número de telefone válido",
+    "invalidUrl": "Por favor, insira uma URL válida"
   },
   "settings": {
     "title": "Configurações",

--- a/tests/unit/composables/useProfileEdit.test.ts
+++ b/tests/unit/composables/useProfileEdit.test.ts
@@ -1,19 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { computed, ref } from 'vue'
-import {
-  useAuthStore as realUseAuthStore
-} from '~/stores/auth'
+import { useAuthStore as realUseAuthStore } from '~/stores/auth'
 import { useProfileEdit } from '~/composables/useProfileEdit'
-import { UserService } from
-  '~/composables/api/services/UserService'
+import { UserService } from '~/composables/api/services/UserService'
 
 // Create a shared form state for vee-validate mocks
 let mockFormValues: Record<string, unknown> = {}
 let mockFieldRefs: Record<string, unknown> = {}
-const mockFormMeta = ref(
-  { valid: true, dirty: false, touched: false }
-)
+const mockFormMeta = ref({ valid: true, dirty: false, touched: false })
 
 // Mock vee-validate
 vi.mock('vee-validate', () => ({
@@ -23,50 +18,33 @@ vi.mock('vee-validate', () => ({
         return mockFormValues
       },
       meta: mockFormMeta,
-      setValues: (
-        values: Record<string, unknown>
-      ) => {
+      setValues: (values: Record<string, unknown>) => {
         mockFormValues = {}
         Object.assign(mockFormValues, values)
         Object.keys(values).forEach(key => {
           if (mockFieldRefs[key]) {
-            ;(
-              mockFieldRefs[key] as
-              { value: unknown }
-            ).value = values[key]
+            ;(mockFieldRefs[key] as { value: unknown }).value = values[key]
           }
         })
       },
-      resetForm: (
-        opts?: { values?: Record<string, unknown> }
-      ) => {
+      resetForm: (opts?: { values?: Record<string, unknown> }) => {
         if (opts?.values) {
           mockFormValues = {}
           Object.assign(mockFormValues, opts.values)
           Object.keys(opts.values).forEach(key => {
             if (mockFieldRefs[key]) {
-              ;(
-                mockFieldRefs[key] as
-                { value: unknown }
-              ).value = opts.values[key]
+              ;(mockFieldRefs[key] as { value: unknown }).value = opts.values[key]
             }
           })
         }
       },
-      setFieldValue: (
-        name: string, value: unknown
-      ) => {
+      setFieldValue: (name: string, value: unknown) => {
         mockFormValues[name] = value
         if (mockFieldRefs[name]) {
-          ;(
-            mockFieldRefs[name] as
-            { value: unknown }
-          ).value = value
+          ;(mockFieldRefs[name] as { value: unknown }).value = value
         }
       },
-      handleSubmit: (
-        fn: (...args: unknown[]) => unknown
-      ) => fn
+      handleSubmit: (fn: (...args: unknown[]) => unknown) => fn
     }
     return formInstance
   }),
@@ -75,10 +53,7 @@ vi.mock('vee-validate', () => ({
       const fieldRef = ref('')
       mockFieldRefs[name] = fieldRef
 
-      const originalSetter = Object
-        .getOwnPropertyDescriptor(
-          fieldRef, 'value'
-        )?.set
+      const originalSetter = Object.getOwnPropertyDescriptor(fieldRef, 'value')?.set
       Object.defineProperty(fieldRef, 'value', {
         get() {
           return mockFormValues[name] ?? ''
@@ -107,33 +82,19 @@ vi.mock('@vee-validate/zod', () => ({
 vi.mock('~/composables/api/services/UserService')
 
 // Mock useErrorHandler
-vi.mock(
-  '~/composables/errors/useErrorHandler',
-  () => ({
-    useErrorHandler: () => ({
-      normalizeError: vi.fn(
-        (error: unknown) => error
-      ),
-      handleError: vi.fn(
-        (error: unknown) => error
-      ),
-      handleApiError: vi.fn(
-        (error: unknown) => error
-      ),
-      handleValidationError: vi.fn(
-        (error: unknown) => error
-      ),
-      handleSilentError: vi.fn(
-        (error: unknown) => error
-      )
-    })
+vi.mock('~/composables/errors/useErrorHandler', () => ({
+  useErrorHandler: () => ({
+    normalizeError: vi.fn((error: unknown) => error),
+    handleError: vi.fn((error: unknown) => error),
+    handleApiError: vi.fn((error: unknown) => error),
+    handleValidationError: vi.fn((error: unknown) => error),
+    handleSilentError: vi.fn((error: unknown) => error)
   })
-)
+}))
 
 describe('useProfileEdit', () => {
   let authStore: ReturnType<typeof realUseAuthStore>
-  const mockRefreshProfile = vi.fn()
-    .mockResolvedValue({})
+  const mockRefreshProfile = vi.fn().mockResolvedValue({})
 
   const mockUser = {
     _id: 'user1',
@@ -151,7 +112,9 @@ describe('useProfileEdit', () => {
     mockFormValues = {}
     mockFieldRefs = {}
     mockFormMeta.value = {
-      valid: true, dirty: false, touched: false
+      valid: true,
+      dirty: false,
+      touched: false
     }
 
     setActivePinia(createPinia())
@@ -181,8 +144,7 @@ describe('useProfileEdit', () => {
   })
 
   it('startEdit toggles isEditing', () => {
-    const { startEdit, isEditing } =
-      useProfileEdit()
+    const { startEdit, isEditing } = useProfileEdit()
 
     expect(isEditing.value).toBe(false)
     startEdit()
@@ -190,42 +152,37 @@ describe('useProfileEdit', () => {
   })
 
   it('empty name produces nameError', () => {
-    const { startEdit, name, hasErrors } =
-      useProfileEdit()
+    const { startEdit, name, hasErrors } = useProfileEdit()
 
     startEdit()
     name.value = ''
     mockFormMeta.value = {
-      valid: false, dirty: true, touched: true
+      valid: false,
+      dirty: true,
+      touched: true
     }
 
     expect(hasErrors.value).toBe(true)
   })
 
-  it(
-    'handleSubmit posts only dirty fields',
-    async () => {
-      const mockUpdateCurrentUser = vi.fn()
-        .mockResolvedValue({ user: mockUser })
+  it('handleSubmit posts only dirty fields', async () => {
+    const mockUpdateCurrentUser = vi.fn().mockResolvedValue({ user: mockUser })
 
-      vi.mocked(UserService).mockImplementation(
-        () =>
-          ({
-            updateCurrentUser: mockUpdateCurrentUser
-          }) as unknown as UserService
-      )
+    vi.mocked(UserService).mockImplementation(
+      () =>
+        ({
+          updateCurrentUser: mockUpdateCurrentUser
+        }) as unknown as UserService
+    )
 
-      const { startEdit, name, saveProfile } =
-        useProfileEdit()
+    const { startEdit, name, saveProfile } = useProfileEdit()
 
-      startEdit()
-      name.value = 'Updated Name'
-      await saveProfile()
+    startEdit()
+    name.value = 'Updated Name'
+    await saveProfile()
 
-      expect(mockUpdateCurrentUser)
-        .toHaveBeenCalledWith({
-          name: 'Updated Name'
-        })
-    }
-  )
+    expect(mockUpdateCurrentUser).toHaveBeenCalledWith({
+      name: 'Updated Name'
+    })
+  })
 })

--- a/tests/unit/composables/useProfileEdit.test.ts
+++ b/tests/unit/composables/useProfileEdit.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { computed, ref } from 'vue'
+import {
+  useAuthStore as realUseAuthStore
+} from '~/stores/auth'
+import { useProfileEdit } from '~/composables/useProfileEdit'
+import { UserService } from
+  '~/composables/api/services/UserService'
+
+// Create a shared form state for vee-validate mocks
+let mockFormValues: Record<string, unknown> = {}
+let mockFieldRefs: Record<string, unknown> = {}
+const mockFormMeta = ref(
+  { valid: true, dirty: false, touched: false }
+)
+
+// Mock vee-validate
+vi.mock('vee-validate', () => ({
+  useForm: vi.fn(() => {
+    const formInstance = {
+      get values() {
+        return mockFormValues
+      },
+      meta: mockFormMeta,
+      setValues: (
+        values: Record<string, unknown>
+      ) => {
+        mockFormValues = {}
+        Object.assign(mockFormValues, values)
+        Object.keys(values).forEach(key => {
+          if (mockFieldRefs[key]) {
+            ;(
+              mockFieldRefs[key] as
+              { value: unknown }
+            ).value = values[key]
+          }
+        })
+      },
+      resetForm: (
+        opts?: { values?: Record<string, unknown> }
+      ) => {
+        if (opts?.values) {
+          mockFormValues = {}
+          Object.assign(mockFormValues, opts.values)
+          Object.keys(opts.values).forEach(key => {
+            if (mockFieldRefs[key]) {
+              ;(
+                mockFieldRefs[key] as
+                { value: unknown }
+              ).value = opts.values[key]
+            }
+          })
+        }
+      },
+      setFieldValue: (
+        name: string, value: unknown
+      ) => {
+        mockFormValues[name] = value
+        if (mockFieldRefs[name]) {
+          ;(
+            mockFieldRefs[name] as
+            { value: unknown }
+          ).value = value
+        }
+      },
+      handleSubmit: (
+        fn: (...args: unknown[]) => unknown
+      ) => fn
+    }
+    return formInstance
+  }),
+  useField: vi.fn((name: string) => {
+    if (!mockFieldRefs[name]) {
+      const fieldRef = ref('')
+      mockFieldRefs[name] = fieldRef
+
+      const originalSetter = Object
+        .getOwnPropertyDescriptor(
+          fieldRef, 'value'
+        )?.set
+      Object.defineProperty(fieldRef, 'value', {
+        get() {
+          return mockFormValues[name] ?? ''
+        },
+        set(newValue) {
+          mockFormValues[name] = newValue
+          if (originalSetter) {
+            originalSetter.call(fieldRef, newValue)
+          }
+        }
+      })
+    }
+    return {
+      value: mockFieldRefs[name],
+      errorMessage: ref(undefined)
+    }
+  })
+}))
+
+// Mock @vee-validate/zod
+vi.mock('@vee-validate/zod', () => ({
+  toTypedSchema: vi.fn(schema => schema)
+}))
+
+// Mock UserService
+vi.mock('~/composables/api/services/UserService')
+
+// Mock useErrorHandler
+vi.mock(
+  '~/composables/errors/useErrorHandler',
+  () => ({
+    useErrorHandler: () => ({
+      normalizeError: vi.fn(
+        (error: unknown) => error
+      ),
+      handleError: vi.fn(
+        (error: unknown) => error
+      ),
+      handleApiError: vi.fn(
+        (error: unknown) => error
+      ),
+      handleValidationError: vi.fn(
+        (error: unknown) => error
+      ),
+      handleSilentError: vi.fn(
+        (error: unknown) => error
+      )
+    })
+  })
+)
+
+describe('useProfileEdit', () => {
+  let authStore: ReturnType<typeof realUseAuthStore>
+  const mockRefreshProfile = vi.fn()
+    .mockResolvedValue({})
+
+  const mockUser = {
+    _id: 'user1',
+    id: 'user1',
+    name: 'Test User',
+    email: 'test@test.com',
+    city: 'Test City',
+    country: 'US'
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Reset mock form state
+    mockFormValues = {}
+    mockFieldRefs = {}
+    mockFormMeta.value = {
+      valid: true, dirty: false, touched: false
+    }
+
+    setActivePinia(createPinia())
+
+    global.useAuthStore = realUseAuthStore
+    authStore = realUseAuthStore()
+    authStore.setToken('test-token')
+    authStore.setUser(mockUser)
+
+    // Override useProfile
+    global.useProfile = () =>
+      ({
+        user: computed(() => mockUser),
+        activeCompany: computed(() => null),
+        userId: computed(() => mockUser._id),
+        companyId: computed(() => ''),
+        refreshProfile: mockRefreshProfile
+      }) as ReturnType<typeof useProfile>
+
+    // Override useToast
+    global.useToast = () =>
+      ({
+        create: vi.fn().mockResolvedValue({
+          present: vi.fn()
+        })
+      }) as ReturnType<typeof useToast>
+  })
+
+  it('startEdit toggles isEditing', () => {
+    const { startEdit, isEditing } =
+      useProfileEdit()
+
+    expect(isEditing.value).toBe(false)
+    startEdit()
+    expect(isEditing.value).toBe(true)
+  })
+
+  it('empty name produces nameError', () => {
+    const { startEdit, name, hasErrors } =
+      useProfileEdit()
+
+    startEdit()
+    name.value = ''
+    mockFormMeta.value = {
+      valid: false, dirty: true, touched: true
+    }
+
+    expect(hasErrors.value).toBe(true)
+  })
+
+  it(
+    'handleSubmit posts only dirty fields',
+    async () => {
+      const mockUpdateCurrentUser = vi.fn()
+        .mockResolvedValue({ user: mockUser })
+
+      vi.mocked(UserService).mockImplementation(
+        () =>
+          ({
+            updateCurrentUser: mockUpdateCurrentUser
+          }) as unknown as UserService
+      )
+
+      const { startEdit, name, saveProfile } =
+        useProfileEdit()
+
+      startEdit()
+      name.value = 'Updated Name'
+      await saveProfile()
+
+      expect(mockUpdateCurrentUser)
+        .toHaveBeenCalledWith({
+          name: 'Updated Name'
+        })
+    }
+  )
+})

--- a/tests/unit/composables/validation/useFormValidation.test.ts
+++ b/tests/unit/composables/validation/useFormValidation.test.ts
@@ -6,7 +6,13 @@ import {
   validationSchemas,
   loginSchema,
   registerSchema,
-  profileSchema
+  profileSchema,
+  registerEmailPasswordSchema,
+  createLoginSchema,
+  createRegisterSchema,
+  createProfileSchema,
+  createRegisterEmailPasswordSchema,
+  createProfileEditSchema
 } from '~/composables/validation/useFormValidation'
 
 describe('useFormValidation', () => {
@@ -407,6 +413,142 @@ describe('useFormValidation', () => {
 
       await form.validate()
       expect(form.meta.value.valid).toBe(true)
+    })
+  })
+
+  describe('registerEmailPasswordSchema', () => {
+    it('should validate correct data', async () => {
+      const form = useFormValidation(
+        registerEmailPasswordSchema,
+        {
+          email: 'test@example.com',
+          password: 'password123'
+        }
+      )
+
+      await form.validate()
+      expect(form.meta.value.valid).toBe(true)
+    })
+
+    it('should reject missing email', async () => {
+      const form = useFormValidation(
+        registerEmailPasswordSchema,
+        { email: '', password: 'password123' }
+      )
+
+      await form.validate()
+      expect(form.errors.value.email).toBeTruthy()
+    })
+
+    it('should reject invalid email', async () => {
+      const form = useFormValidation(
+        registerEmailPasswordSchema,
+        {
+          email: 'not-an-email',
+          password: 'password123'
+        }
+      )
+
+      await form.validate()
+      expect(form.errors.value.email)
+        .toContain('valid email')
+    })
+
+    it('should reject short password', async () => {
+      const form = useFormValidation(
+        registerEmailPasswordSchema,
+        { email: 'test@example.com', password: 'abc' }
+      )
+
+      await form.validate()
+      expect(form.errors.value.password)
+        .toContain('8 characters')
+    })
+  })
+
+  describe('translator injection', () => {
+    const stubT = (
+      k: string,
+      p?: Record<string, unknown>
+    ) => `T:${k}:${JSON.stringify(p ?? {})}`
+
+    it('createLoginSchema uses translator', () => {
+      const schema = createLoginSchema(stubT)
+      const result = schema.safeParse(
+        { email: '', password: '' }
+      )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues
+          .map((i) => i.message)
+        expect(
+          msgs.some((m) => m.startsWith('T:'))
+        ).toBe(true)
+      }
+    })
+
+    it('createRegisterSchema uses translator', () => {
+      const schema = createRegisterSchema(stubT)
+      const result = schema.safeParse(
+        { name: '', email: '', password: '' }
+      )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues
+          .map((i) => i.message)
+        expect(
+          msgs.some((m) => m.startsWith('T:'))
+        ).toBe(true)
+      }
+    })
+
+    it('createProfileSchema uses translator', () => {
+      const schema = createProfileSchema(stubT)
+      const result = schema.safeParse(
+        { name: '', email: '' }
+      )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues
+          .map((i) => i.message)
+        expect(
+          msgs.some((m) => m.startsWith('T:'))
+        ).toBe(true)
+      }
+    })
+
+    it(
+      'createRegisterEmailPasswordSchema uses translator',
+      () => {
+        const schema =
+          createRegisterEmailPasswordSchema(stubT)
+        const result = schema.safeParse(
+          { email: '', password: '' }
+        )
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          const msgs = result.error.issues
+            .map((i) => i.message)
+          expect(
+            msgs.some((m) => m.startsWith('T:'))
+          ).toBe(true)
+        }
+      }
+    )
+
+    it('createProfileEditSchema uses translator', () => {
+      const schema = createProfileEditSchema(stubT)
+      const result = schema.safeParse(
+        { name: '', email: '' }
+      )
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues
+          .map((i) => i.message)
+        expect(
+          msgs.some((m) => m.startsWith('T:'))
+        ).toBe(true)
+      }
     })
   })
 })

--- a/tests/unit/composables/validation/useFormValidation.test.ts
+++ b/tests/unit/composables/validation/useFormValidation.test.ts
@@ -418,136 +418,96 @@ describe('useFormValidation', () => {
 
   describe('registerEmailPasswordSchema', () => {
     it('should validate correct data', async () => {
-      const form = useFormValidation(
-        registerEmailPasswordSchema,
-        {
-          email: 'test@example.com',
-          password: 'password123'
-        }
-      )
+      const form = useFormValidation(registerEmailPasswordSchema, {
+        email: 'test@example.com',
+        password: 'password123'
+      })
 
       await form.validate()
       expect(form.meta.value.valid).toBe(true)
     })
 
     it('should reject missing email', async () => {
-      const form = useFormValidation(
-        registerEmailPasswordSchema,
-        { email: '', password: 'password123' }
-      )
+      const form = useFormValidation(registerEmailPasswordSchema, {
+        email: '',
+        password: 'password123'
+      })
 
       await form.validate()
       expect(form.errors.value.email).toBeTruthy()
     })
 
     it('should reject invalid email', async () => {
-      const form = useFormValidation(
-        registerEmailPasswordSchema,
-        {
-          email: 'not-an-email',
-          password: 'password123'
-        }
-      )
+      const form = useFormValidation(registerEmailPasswordSchema, {
+        email: 'not-an-email',
+        password: 'password123'
+      })
 
       await form.validate()
-      expect(form.errors.value.email)
-        .toContain('valid email')
+      expect(form.errors.value.email).toContain('valid email')
     })
 
     it('should reject short password', async () => {
-      const form = useFormValidation(
-        registerEmailPasswordSchema,
-        { email: 'test@example.com', password: 'abc' }
-      )
+      const form = useFormValidation(registerEmailPasswordSchema, {
+        email: 'test@example.com',
+        password: 'abc'
+      })
 
       await form.validate()
-      expect(form.errors.value.password)
-        .toContain('8 characters')
+      expect(form.errors.value.password).toContain('8 characters')
     })
   })
 
   describe('translator injection', () => {
-    const stubT = (
-      k: string,
-      p?: Record<string, unknown>
-    ) => `T:${k}:${JSON.stringify(p ?? {})}`
+    const stubT = (k: string, p?: Record<string, unknown>) => `T:${k}:${JSON.stringify(p ?? {})}`
 
     it('createLoginSchema uses translator', () => {
       const schema = createLoginSchema(stubT)
-      const result = schema.safeParse(
-        { email: '', password: '' }
-      )
+      const result = schema.safeParse({ email: '', password: '' })
       expect(result.success).toBe(false)
       if (!result.success) {
-        const msgs = result.error.issues
-          .map((i) => i.message)
-        expect(
-          msgs.some((m) => m.startsWith('T:'))
-        ).toBe(true)
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
       }
     })
 
     it('createRegisterSchema uses translator', () => {
       const schema = createRegisterSchema(stubT)
-      const result = schema.safeParse(
-        { name: '', email: '', password: '' }
-      )
+      const result = schema.safeParse({ name: '', email: '', password: '' })
       expect(result.success).toBe(false)
       if (!result.success) {
-        const msgs = result.error.issues
-          .map((i) => i.message)
-        expect(
-          msgs.some((m) => m.startsWith('T:'))
-        ).toBe(true)
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
       }
     })
 
     it('createProfileSchema uses translator', () => {
       const schema = createProfileSchema(stubT)
-      const result = schema.safeParse(
-        { name: '', email: '' }
-      )
+      const result = schema.safeParse({ name: '', email: '' })
       expect(result.success).toBe(false)
       if (!result.success) {
-        const msgs = result.error.issues
-          .map((i) => i.message)
-        expect(
-          msgs.some((m) => m.startsWith('T:'))
-        ).toBe(true)
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
       }
     })
 
-    it(
-      'createRegisterEmailPasswordSchema uses translator',
-      () => {
-        const schema =
-          createRegisterEmailPasswordSchema(stubT)
-        const result = schema.safeParse(
-          { email: '', password: '' }
-        )
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          const msgs = result.error.issues
-            .map((i) => i.message)
-          expect(
-            msgs.some((m) => m.startsWith('T:'))
-          ).toBe(true)
-        }
+    it('createRegisterEmailPasswordSchema uses translator', () => {
+      const schema = createRegisterEmailPasswordSchema(stubT)
+      const result = schema.safeParse({ email: '', password: '' })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
       }
-    )
+    })
 
     it('createProfileEditSchema uses translator', () => {
       const schema = createProfileEditSchema(stubT)
-      const result = schema.safeParse(
-        { name: '', email: '' }
-      )
+      const result = schema.safeParse({ name: '', city: '', country: '' })
       expect(result.success).toBe(false)
       if (!result.success) {
-        const msgs = result.error.issues
-          .map((i) => i.message)
-        expect(
-          msgs.some((m) => m.startsWith('T:'))
-        ).toBe(true)
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
       }
     })
   })


### PR DESCRIPTION
## Summary

- Port translator-factory pattern (`createFallbackTranslator`, `fallbackMessages`, `resolveMessage`, `interpolate`) from golden reference into central `useFormValidation.ts`
- Add factory + pre-built pairs for all schemas: `createLoginSchema`, `createRegisterSchema`, `createProfileSchema`, `createRegisterEmailPasswordSchema`, `createProfileEditSchema`, `createCompanyEditSchema`
- Migrate `RegisterForm.vue` from plain `ref()` + HTML `required` to Zod-driven `useFormValidation` with `ion-note` error display and `isValid` gating
- Switch `LoginForm.vue` to live i18n via `createLoginSchema(t)`
- Replace inline `z.object({...})` in `useProfileEdit.ts` with `createProfileEditSchema(t)`
- Relocate `companySchemas.ts` factory into central module (thin re-export kept for existing test imports)
- Add "Form validation conventions" section to `docs/PRD.md`

## Test plan

- [x] All 566 existing tests pass (29 test files)
- [x] 8 new schema factory + translator injection tests added
- [x] 3 new `useProfileEdit` public surface tests added
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] `npm run generate` passes
- [ ] Manual: register new account, verify inline errors appear
- [ ] Manual: edit profile/company on `/account`, verify validation
- [ ] Manual: switch locale and verify translated error messages

Closes #25

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now uses translator-backed schemas with improved field-level error messages and tighter submit/disable behavior on auth and profile forms.
  * Added localized validation strings for company phone/URL in multiple locales.

* **Documentation**
  * New "Form Validation Conventions" guidance added.

* **Tests**
  * Unit tests added/expanded for profile editing and validation schema behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->