### PR TITLE
feat: wire complete password reset flow

### DIFF
--- a/app/components/auth/PasswordResetConfirmForm.vue
+++ b/app/components/auth/PasswordResetConfirmForm.vue
@@ -1,0 +1,89 @@
+<template>
+  <form @submit.prevent="onSubmit">
+    <ion-item>
+      <ion-label position="stacked">
+        {{ $t('auth.passwordReset.newPassword') }}
+      </ion-label>
+      <ion-input
+        v-model="password"
+        type="password"
+        :placeholder="$t('auth.enterPassword')"
+        required
+      />
+      <ion-note v-if="errors.password" color="danger">
+        {{ errors.password }}
+      </ion-note>
+    </ion-item>
+
+    <ion-item>
+      <ion-label position="stacked">
+        {{ $t('auth.passwordReset.confirmPassword') }}
+      </ion-label>
+      <ion-input
+        v-model="confirmPassword"
+        type="password"
+        :placeholder="$t('auth.confirmPassword')"
+        required
+      />
+      <ion-note v-if="errors.confirmPassword" color="danger">
+        {{ errors.confirmPassword }}
+      </ion-note>
+    </ion-item>
+
+    <div class="button-container">
+      <ion-button
+        expand="block"
+        type="submit"
+        :disabled="loading || !isValid"
+        class="ion-margin-top"
+      >
+        <ion-spinner v-if="loading" name="crescent" />
+        <span v-else>
+          {{ $t('auth.passwordReset.submitButton') }}
+        </span>
+      </ion-button>
+    </div>
+
+    <ion-text v-if="error" color="danger" class="ion-margin-top">
+      <p>{{ error }}</p>
+    </ion-text>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import {
+  createResetPasswordConfirmSchema,
+  useFormValidation
+} from '~/composables/validation/useFormValidation'
+
+interface Props {
+  loading?: boolean
+  error?: string
+}
+
+interface Emits {
+  submit: [payload: { password: string }]
+}
+
+withDefaults(defineProps<Props>(), {
+  loading: false,
+  error: ''
+})
+
+const emit = defineEmits<Emits>()
+
+const { t } = useI18n()
+const schema = createResetPasswordConfirmSchema(t)
+const { handleSubmit, defineField, errors, isValid } = useFormValidation(schema, {
+  password: '',
+  confirmPassword: ''
+})
+
+const [password] = defineField('password' as const)
+const [confirmPassword] = defineField('confirmPassword' as const)
+
+const onSubmit = handleSubmit(values => {
+  emit('submit', { password: values.password })
+})
+</script>

--- a/app/components/auth/PasswordResetRequestForm.vue
+++ b/app/components/auth/PasswordResetRequestForm.vue
@@ -1,0 +1,59 @@
+<template>
+  <form @submit.prevent="onSubmit">
+    <ion-item>
+      <ion-label position="stacked">
+        {{ $t('auth.email') }}
+      </ion-label>
+      <ion-input v-model="email" type="email" :placeholder="$t('auth.enterEmail')" required />
+      <ion-note v-if="errors.email" color="danger">
+        {{ errors.email }}
+      </ion-note>
+    </ion-item>
+
+    <div class="button-container">
+      <ion-button
+        expand="block"
+        type="submit"
+        :disabled="loading || !isValid"
+        class="ion-margin-top"
+      >
+        <ion-spinner v-if="loading" name="crescent" />
+        <span v-else>
+          {{ $t('auth.passwordReset.requestButton') }}
+        </span>
+      </ion-button>
+    </div>
+  </form>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import {
+  createResetPasswordRequestSchema,
+  useFormValidation
+} from '~/composables/validation/useFormValidation'
+
+interface Props {
+  loading?: boolean
+}
+
+interface Emits {
+  submit: [payload: { email: string }]
+}
+
+withDefaults(defineProps<Props>(), {
+  loading: false
+})
+
+const emit = defineEmits<Emits>()
+
+const { t } = useI18n()
+const schema = createResetPasswordRequestSchema(t)
+const { handleSubmit, defineField, errors, isValid } = useFormValidation(schema, { email: '' })
+
+const [email] = defineField('email' as const)
+
+const onSubmit = handleSubmit(values => {
+  emit('submit', { email: values.email })
+})
+</script>

--- a/app/composables/api/services/AuthService.ts
+++ b/app/composables/api/services/AuthService.ts
@@ -55,6 +55,13 @@ export class AuthService {
   }
 
   /**
+   * Confirm password reset with token
+   */
+  async confirmPasswordReset(token: string, newPassword: string) {
+    return this.authRepository.confirmPasswordReset(token, newPassword)
+  }
+
+  /**
    * Verify email with token and handle authentication
    */
   async verifyEmail(token: string) {

--- a/app/composables/auth/usePasswordReset.ts
+++ b/app/composables/auth/usePasswordReset.ts
@@ -22,23 +22,16 @@ export function usePasswordReset() {
     return { success: true }
   }
 
-  const confirmReset = async (
-    { token, password }: { token: string; password: string }
-  ) => {
+  const confirmReset = async ({ token, password }: { token: string; password: string }) => {
     loading.value = true
     try {
       try {
         await confirmPasswordReset(token, password)
       } catch (err: unknown) {
-        handleApiError(
-          err as import('ofetch').FetchError,
-          'usePasswordReset.confirmReset'
-        )
+        handleApiError(err as import('ofetch').FetchError, 'usePasswordReset.confirmReset')
         return
       }
-      await toast.showSuccess(
-        t('auth.passwordReset.successToast')
-      )
+      await toast.showSuccess(t('auth.passwordReset.successToast'))
       await navigateTo(localePath('/login'))
     } finally {
       loading.value = false

--- a/app/composables/auth/usePasswordReset.ts
+++ b/app/composables/auth/usePasswordReset.ts
@@ -1,0 +1,43 @@
+import { useI18n } from 'vue-i18n'
+import { useErrorHandler } from '../errors/useErrorHandler'
+
+export function usePasswordReset() {
+  const { sendPasswordReset, confirmPasswordReset } = useAuth()
+  const toast = useToast()
+  const { handleApiError, handleSilentError } = useErrorHandler()
+  const { t } = useI18n()
+  const localePath = useLocalePath()
+
+  const loading = ref(false)
+
+  const requestReset = async (email: string) => {
+    loading.value = true
+    try {
+      await sendPasswordReset(email)
+    } catch (err: unknown) {
+      handleSilentError(err, 'usePasswordReset.requestReset')
+    } finally {
+      loading.value = false
+    }
+    return { success: true }
+  }
+
+  const confirmReset = async ({ token, password }: { token: string; password: string }) => {
+    loading.value = true
+    try {
+      await confirmPasswordReset(token, password)
+      await toast.showSuccess(t('auth.passwordReset.successToast'))
+      await navigateTo(localePath('/login'))
+    } catch (err: unknown) {
+      handleApiError(err as import('ofetch').FetchError, 'usePasswordReset.confirmReset')
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    loading: readonly(loading),
+    requestReset,
+    confirmReset
+  }
+}

--- a/app/composables/auth/usePasswordReset.ts
+++ b/app/composables/auth/usePasswordReset.ts
@@ -22,14 +22,24 @@ export function usePasswordReset() {
     return { success: true }
   }
 
-  const confirmReset = async ({ token, password }: { token: string; password: string }) => {
+  const confirmReset = async (
+    { token, password }: { token: string; password: string }
+  ) => {
     loading.value = true
     try {
-      await confirmPasswordReset(token, password)
-      await toast.showSuccess(t('auth.passwordReset.successToast'))
+      try {
+        await confirmPasswordReset(token, password)
+      } catch (err: unknown) {
+        handleApiError(
+          err as import('ofetch').FetchError,
+          'usePasswordReset.confirmReset'
+        )
+        return
+      }
+      await toast.showSuccess(
+        t('auth.passwordReset.successToast')
+      )
       await navigateTo(localePath('/login'))
-    } catch (err: unknown) {
-      handleApiError(err as import('ofetch').FetchError, 'usePasswordReset.confirmReset')
     } finally {
       loading.value = false
     }

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -20,6 +20,14 @@ export const useAuth = () => {
     return authService.sendPasswordReset(email)
   }
 
+  const confirmPasswordReset = async (token: string, newPassword: string) => {
+    return authService.confirmPasswordReset(token, newPassword)
+  }
+
+  const sendRegisterToken = async (email: string) => {
+    return authService.sendRegisterToken(email)
+  }
+
   const verifyEmail = async (token: string) => {
     return authService.verifyEmail(token)
   }
@@ -33,6 +41,8 @@ export const useAuth = () => {
     logout,
     register,
     sendPasswordReset,
+    confirmPasswordReset,
+    sendRegisterToken,
     verifyEmail,
     setToken,
     user: computed(() => authStore.user),

--- a/app/composables/validation/useFormValidation.ts
+++ b/app/composables/validation/useFormValidation.ts
@@ -111,6 +111,26 @@ export const createRegisterEmailPasswordSchema = (t: TranslateFn) => {
   })
 }
 
+export const createResetPasswordRequestSchema = (t: TranslateFn) => {
+  const f = createValidationFragments(t)
+  return z.object({
+    email: f.email
+  })
+}
+
+export const createResetPasswordConfirmSchema = (t: TranslateFn) => {
+  const f = createValidationFragments(t)
+  return z
+    .object({
+      password: f.password,
+      confirmPassword: f.password
+    })
+    .refine(data => data.password === data.confirmPassword, {
+      message: t('validation.passwordMatch'),
+      path: ['confirmPassword']
+    })
+}
+
 export const createProfileEditSchema = (t: TranslateFn) =>
   z.object({
     name: z.string().min(1, t('validation.profile.nameRequired')),
@@ -152,6 +172,10 @@ export const profileSchema = toTypedSchema(createProfileSchema(fallbackT))
 export const registerEmailPasswordSchema = toTypedSchema(
   createRegisterEmailPasswordSchema(fallbackT)
 )
+
+export const resetPasswordRequestSchema = toTypedSchema(createResetPasswordRequestSchema(fallbackT))
+
+export const resetPasswordConfirmSchema = toTypedSchema(createResetPasswordConfirmSchema(fallbackT))
 
 export function useFormValidation<T extends Record<string, unknown>>(
   schema: ZodSchema<T> | ReturnType<typeof toTypedSchema>,

--- a/app/pages/auth/reset-password/confirm.vue
+++ b/app/pages/auth/reset-password/confirm.vue
@@ -48,7 +48,12 @@ const route = useRoute()
 const localePath = useLocalePath()
 const { loading, confirmReset } = usePasswordReset()
 
-const token = computed(() => route.query.token as string | undefined)
+const token = computed(() => {
+  const rawToken = route.query.token
+  return typeof rawToken === 'string' && rawToken.length > 0
+    ? rawToken
+    : undefined
+})
 
 const handleConfirm = async (payload: { password: string }) => {
   if (!token.value) return

--- a/app/pages/auth/reset-password/confirm.vue
+++ b/app/pages/auth/reset-password/confirm.vue
@@ -1,0 +1,60 @@
+<template>
+  <ion-grid class="ion-padding">
+    <ion-row class="ion-justify-content-center">
+      <ion-col size="12" size-sm="6" size-md="5" size-lg="5">
+        <template v-if="token">
+          <div class="ion-text-center ion-padding-vertical">
+            <ion-text>
+              <h1>
+                {{ $t('auth.passwordReset.confirmTitle') }}
+              </h1>
+            </ion-text>
+            <ion-text color="medium">
+              <p>
+                {{ $t('auth.passwordReset.confirmSubtitle') }}
+              </p>
+            </ion-text>
+          </div>
+
+          <AuthPasswordResetConfirmForm :loading="loading" @submit="handleConfirm" />
+        </template>
+
+        <div v-else class="ion-text-center ion-padding-vertical">
+          <ion-text color="danger">
+            <p>
+              {{ $t('auth.passwordReset.invalidToken') }}
+            </p>
+          </ion-text>
+          <NuxtLink :to="localePath('/auth/reset-password')">
+            <ion-button fill="clear" size="small">
+              {{ $t('auth.passwordReset.requestButton') }}
+            </ion-button>
+          </NuxtLink>
+        </div>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</template>
+
+<script setup lang="ts">
+import { usePasswordReset } from '~/composables/auth/usePasswordReset'
+
+definePageMeta({
+  layout: 'public',
+  middleware: 'guest'
+})
+
+const route = useRoute()
+const localePath = useLocalePath()
+const { loading, confirmReset } = usePasswordReset()
+
+const token = computed(() => route.query.token as string | undefined)
+
+const handleConfirm = async (payload: { password: string }) => {
+  if (!token.value) return
+  await confirmReset({
+    token: token.value,
+    password: payload.password
+  })
+}
+</script>

--- a/app/pages/auth/reset-password/confirm.vue
+++ b/app/pages/auth/reset-password/confirm.vue
@@ -50,9 +50,7 @@ const { loading, confirmReset } = usePasswordReset()
 
 const token = computed(() => {
   const rawToken = route.query.token
-  return typeof rawToken === 'string' && rawToken.length > 0
-    ? rawToken
-    : undefined
+  return typeof rawToken === 'string' && rawToken.length > 0 ? rawToken : undefined
 })
 
 const handleConfirm = async (payload: { password: string }) => {

--- a/app/pages/auth/reset-password/index.vue
+++ b/app/pages/auth/reset-password/index.vue
@@ -1,0 +1,60 @@
+<template>
+  <ion-grid class="ion-padding">
+    <ion-row class="ion-justify-content-center">
+      <ion-col size="12" size-sm="6" size-md="5" size-lg="5">
+        <div class="ion-text-center ion-padding-vertical">
+          <ion-text>
+            <h1>
+              {{ $t('auth.passwordReset.requestTitle') }}
+            </h1>
+          </ion-text>
+          <ion-text color="medium">
+            <p>
+              {{ $t('auth.passwordReset.requestSubtitle') }}
+            </p>
+          </ion-text>
+        </div>
+
+        <AuthPasswordResetRequestForm
+          v-if="!submitted"
+          :loading="loading"
+          @submit="handleRequest"
+        />
+
+        <div v-else class="ion-text-center ion-padding-vertical">
+          <ion-text color="success">
+            <p>
+              {{ $t('auth.passwordReset.requestSuccess') }}
+            </p>
+          </ion-text>
+        </div>
+
+        <div class="ion-text-center ion-margin-top">
+          <NuxtLink :to="localePath('/login')">
+            <ion-button fill="clear" size="small">
+              {{ $t('auth.signInLink') }}
+            </ion-button>
+          </NuxtLink>
+        </div>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</template>
+
+<script setup lang="ts">
+import { usePasswordReset } from '~/composables/auth/usePasswordReset'
+
+definePageMeta({
+  layout: 'public',
+  middleware: 'guest'
+})
+
+const localePath = useLocalePath()
+const { loading, requestReset } = usePasswordReset()
+const submitted = ref(false)
+
+const handleRequest = async (payload: { email: string }) => {
+  await requestReset(payload.email)
+  submitted.value = true
+}
+</script>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -14,6 +14,14 @@
         <AuthLoginForm :loading="loading" :error="error" @submit="handleLogin" />
 
         <div class="ion-text-center ion-margin-top">
+          <NuxtLink :to="localePath('/auth/reset-password')">
+            <ion-button fill="clear" size="small">
+              {{ $t('auth.forgotPassword') }}
+            </ion-button>
+          </NuxtLink>
+        </div>
+
+        <div class="ion-text-center ion-margin-top">
           <ion-text color="medium">
             <p>{{ $t('auth.dontHaveAccount') }}</p>
           </ion-text>

--- a/app/pages/verify-token.vue
+++ b/app/pages/verify-token.vue
@@ -98,17 +98,19 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-import { AuthService } from '~/composables/api/services/AuthService'
+import { useErrorHandler } from '~/composables/errors/useErrorHandler'
 
 definePageMeta({
   middleware: 'guest'
 })
 
-const { verifyEmail } = useAuth()
+const { verifyEmail, sendRegisterToken } = useAuth()
 const { initializeCompany } = useCompanyInitialization()
 const localePath = useLocalePath()
 const { t } = useI18n()
 const { mail, businessOutline } = useIcons()
+const toast = useToast()
+const { handleApiError } = useErrorHandler()
 
 // Get email from local storage
 const storage = useStorage()
@@ -200,14 +202,10 @@ const resendCode = async () => {
   resending.value = true
 
   try {
-    const authService = new AuthService()
-    await authService.sendRegisterToken(registrationEmail as string)
-
-    // Show success message or toast
-    // TODO: Add toast notification
+    await sendRegisterToken(registrationEmail as string)
+    toast.showSuccess(t('auth.verificationCodeSentSuccess'))
   } catch (err: unknown) {
-    const errorObj = err as { data?: { detail?: string } }
-    error.value = errorObj.data?.detail || t('errors.resendFailed')
+    handleApiError(err as import('ofetch').FetchError, 'verify-token.resendCode')
   } finally {
     resending.value = false
   }

--- a/app/pages/verify-token.vue
+++ b/app/pages/verify-token.vue
@@ -203,7 +203,7 @@ const resendCode = async () => {
 
   try {
     await sendRegisterToken(registrationEmail as string)
-    toast.showSuccess(t('auth.verificationCodeSentSuccess'))
+    await toast.showSuccess(t('auth.verificationCodeSentSuccess'))
   } catch (err: unknown) {
     handleApiError(err as import('ofetch').FetchError, 'verify-token.resendCode')
   } finally {

--- a/i18n/locales/de-DE.json
+++ b/i18n/locales/de-DE.json
@@ -83,7 +83,20 @@
     "creatingWorkspace": "Ihr Arbeitsbereich wird erstellt...",
     "settingUpCompany": "Ihr Unternehmen und Ihre Bereiche werden eingerichtet...",
     "retryCreation": "Erneut versuchen",
-    "skipForNow": "Vorläufig überspringen"
+    "skipForNow": "Vorläufig überspringen",
+    "passwordReset": {
+      "requestTitle": "Passwort zurücksetzen",
+      "requestSubtitle": "Geben Sie Ihre E-Mail ein und wir senden Ihnen einen Link zum Zurücksetzen",
+      "requestButton": "Link zum Zurücksetzen senden",
+      "requestSuccess": "Falls ein Konto mit dieser E-Mail existiert, erhalten Sie in Kürze einen Link zum Zurücksetzen des Passworts.",
+      "confirmTitle": "Neues Passwort festlegen",
+      "confirmSubtitle": "Geben Sie unten Ihr neues Passwort ein",
+      "newPassword": "Neues Passwort",
+      "confirmPassword": "Passwort bestätigen",
+      "submitButton": "Passwort zurücksetzen",
+      "successToast": "Passwort erfolgreich zurückgesetzt! Bitte melden Sie sich an.",
+      "invalidToken": "Ungültiger oder fehlender Token. Bitte fordern Sie einen neuen Link an."
+    }
   },
   "home": {
     "title": "BSF Tutorials",

--- a/i18n/locales/en-US.json
+++ b/i18n/locales/en-US.json
@@ -89,7 +89,20 @@
     "creatingWorkspace": "Creating your workspace...",
     "settingUpCompany": "Setting up your company and spaces...",
     "retryCreation": "Retry",
-    "skipForNow": "Skip for now"
+    "skipForNow": "Skip for now",
+    "passwordReset": {
+      "requestTitle": "Reset Password",
+      "requestSubtitle": "Enter your email and we'll send you a reset link",
+      "requestButton": "Send Reset Link",
+      "requestSuccess": "If an account exists with that email, you will receive a password reset link shortly.",
+      "confirmTitle": "Set New Password",
+      "confirmSubtitle": "Enter your new password below",
+      "newPassword": "New Password",
+      "confirmPassword": "Confirm Password",
+      "submitButton": "Reset Password",
+      "successToast": "Password reset successfully! Please sign in.",
+      "invalidToken": "Invalid or missing reset token. Please request a new reset link."
+    }
   },
   "home": {
     "title": "BSF Tutorials",

--- a/i18n/locales/es-ES.json
+++ b/i18n/locales/es-ES.json
@@ -84,7 +84,20 @@
     "creatingWorkspace": "Creando tu espacio de trabajo...",
     "settingUpCompany": "Configurando tu empresa y espacios...",
     "retryCreation": "Reintentar",
-    "skipForNow": "Omitir por ahora"
+    "skipForNow": "Omitir por ahora",
+    "passwordReset": {
+      "requestTitle": "Restablecer contraseña",
+      "requestSubtitle": "Ingrese su correo electrónico y le enviaremos un enlace para restablecer",
+      "requestButton": "Enviar enlace de restablecimiento",
+      "requestSuccess": "Si existe una cuenta con ese correo electrónico, recibirá un enlace para restablecer su contraseña en breve.",
+      "confirmTitle": "Establecer nueva contraseña",
+      "confirmSubtitle": "Ingrese su nueva contraseña a continuación",
+      "newPassword": "Nueva contraseña",
+      "confirmPassword": "Confirmar contraseña",
+      "submitButton": "Restablecer contraseña",
+      "successToast": "¡Contraseña restablecida con éxito! Por favor, inicie sesión.",
+      "invalidToken": "Token inválido o faltante. Por favor, solicite un nuevo enlace."
+    }
   },
   "home": {
     "title": "BSF Tutorials",

--- a/i18n/locales/fr-FR.json
+++ b/i18n/locales/fr-FR.json
@@ -83,7 +83,20 @@
     "creatingWorkspace": "Création de votre espace de travail...",
     "settingUpCompany": "Configuration de votre entreprise et de vos espaces...",
     "retryCreation": "Réessayer",
-    "skipForNow": "Ignorer pour l'instant"
+    "skipForNow": "Ignorer pour l'instant",
+    "passwordReset": {
+      "requestTitle": "Réinitialiser le mot de passe",
+      "requestSubtitle": "Entrez votre e-mail et nous vous enverrons un lien de réinitialisation",
+      "requestButton": "Envoyer le lien de réinitialisation",
+      "requestSuccess": "Si un compte existe avec cette adresse e-mail, vous recevrez un lien de réinitialisation sous peu.",
+      "confirmTitle": "Définir un nouveau mot de passe",
+      "confirmSubtitle": "Entrez votre nouveau mot de passe ci-dessous",
+      "newPassword": "Nouveau mot de passe",
+      "confirmPassword": "Confirmer le mot de passe",
+      "submitButton": "Réinitialiser le mot de passe",
+      "successToast": "Mot de passe réinitialisé avec succès ! Veuillez vous connecter.",
+      "invalidToken": "Jeton invalide ou manquant. Veuillez demander un nouveau lien."
+    }
   },
   "home": {
     "title": "BSF Tutorials",

--- a/i18n/locales/pt-BR.json
+++ b/i18n/locales/pt-BR.json
@@ -83,7 +83,20 @@
     "creatingWorkspace": "Criando seu espaço de trabalho...",
     "settingUpCompany": "Configurando sua empresa e ambientes...",
     "retryCreation": "Tentar novamente",
-    "skipForNow": "Pular por enquanto"
+    "skipForNow": "Pular por enquanto",
+    "passwordReset": {
+      "requestTitle": "Redefinir senha",
+      "requestSubtitle": "Digite seu e-mail e enviaremos um link de redefinição",
+      "requestButton": "Enviar link de redefinição",
+      "requestSuccess": "Se existir uma conta com esse e-mail, você receberá um link de redefinição em breve.",
+      "confirmTitle": "Definir nova senha",
+      "confirmSubtitle": "Digite sua nova senha abaixo",
+      "newPassword": "Nova senha",
+      "confirmPassword": "Confirmar senha",
+      "submitButton": "Redefinir senha",
+      "successToast": "Senha redefinida com sucesso! Por favor, faça login.",
+      "invalidToken": "Token inválido ou ausente. Por favor, solicite um novo link."
+    }
   },
   "home": {
     "title": "BSF Tutorials",

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -90,8 +90,7 @@ test.describe('Password Reset Flow', () => {
 
     const confirmResponse = page.waitForResponse(
       response =>
-        response.url().includes('/reset-password/confirm') &&
-        response.request().method() === 'POST'
+        response.url().includes('/reset-password/confirm') && response.request().method() === 'POST'
     )
     await page.locator('ion-button[type="submit"]').click()
     await confirmResponse
@@ -100,9 +99,7 @@ test.describe('Password Reset Flow', () => {
     await expect(page).toHaveURL(/\/confirm/)
 
     // Should show error toast
-    await expect(
-      page.locator('ion-toast')
-    ).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('ion-toast')).toBeVisible({ timeout: 5000 })
 
     // Should NOT have navigated to login
     expect(page.url()).not.toMatch(/\/login/)

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -88,13 +88,21 @@ test.describe('Password Reset Flow', () => {
     await passwordInputs.nth(0).locator('input').fill('NewSecurePass1')
     await passwordInputs.nth(1).locator('input').fill('NewSecurePass1')
 
+    const confirmResponse = page.waitForResponse(
+      response =>
+        response.url().includes('/reset-password/confirm') &&
+        response.request().method() === 'POST'
+    )
     await page.locator('ion-button[type="submit"]').click()
-
-    // Wait a moment for any potential navigation
-    await page.waitForTimeout(2000)
+    await confirmResponse
 
     // Should stay on confirm page (NOT redirected to /login)
     await expect(page).toHaveURL(/\/confirm/)
+
+    // Should show error toast
+    await expect(
+      page.locator('ion-toast')
+    ).toBeVisible({ timeout: 5000 })
 
     // Should NOT have navigated to login
     expect(page.url()).not.toMatch(/\/login/)

--- a/tests/e2e/password-reset.spec.ts
+++ b/tests/e2e/password-reset.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Password Reset Flow', () => {
+  test('happy path: request and confirm resets password', async ({ page }) => {
+    // Stub request endpoint - always returns success
+    await page.route('**/auth/reset-password', route => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Email sent' })
+        })
+      }
+      return route.continue()
+    })
+
+    // Stub confirm endpoint
+    await page.route('**/auth/reset-password/confirm', route => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Password reset' })
+        })
+      }
+      return route.continue()
+    })
+
+    // --- Request page ---
+    await page.goto('/auth/reset-password')
+    await page.waitForLoadState('networkidle')
+
+    // Fill email and submit
+    const emailInput = page.locator('ion-input[type="email"]')
+    await emailInput.locator('input').fill('user@example.com')
+    await page.locator('ion-button[type="submit"]').click()
+
+    // Assert generic success message (does not reveal account existence)
+    await expect(page.getByText(/if an account exists/i)).toBeVisible()
+
+    // --- Confirm page ---
+    await page.goto('/auth/reset-password/confirm?token=abc123')
+    await page.waitForLoadState('networkidle')
+
+    // Fill both password fields
+    const passwordInputs = page.locator('ion-input[type="password"]')
+    await passwordInputs.nth(0).locator('input').fill('NewSecurePass1')
+    await passwordInputs.nth(1).locator('input').fill('NewSecurePass1')
+
+    await page.locator('ion-button[type="submit"]').click()
+
+    // Should redirect to login after successful reset
+    await expect(page).toHaveURL(/\/login/, { timeout: 10000 })
+  })
+
+  test('missing token shows error and hides form', async ({ page }) => {
+    await page.goto('/auth/reset-password/confirm')
+    await page.waitForLoadState('networkidle')
+
+    // Assert invalid/missing token error message
+    await expect(page.getByText(/invalid.*token|missing.*token/i)).toBeVisible()
+
+    // Confirm form should NOT be rendered (no password inputs)
+    await expect(page.locator('ion-input[type="password"]')).toHaveCount(0)
+
+    // Submit button from confirm form should not exist
+    await expect(page.locator('form ion-button[type="submit"]')).toHaveCount(0)
+  })
+
+  test('backend 400 shows error and stays on page', async ({ page }) => {
+    // Stub confirm endpoint to return 400
+    await page.route('**/auth/reset-password/confirm', route => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Token expired' })
+        })
+      }
+      return route.continue()
+    })
+
+    await page.goto('/auth/reset-password/confirm?token=expired')
+    await page.waitForLoadState('networkidle')
+
+    // Fill both password fields
+    const passwordInputs = page.locator('ion-input[type="password"]')
+    await passwordInputs.nth(0).locator('input').fill('NewSecurePass1')
+    await passwordInputs.nth(1).locator('input').fill('NewSecurePass1')
+
+    await page.locator('ion-button[type="submit"]').click()
+
+    // Wait a moment for any potential navigation
+    await page.waitForTimeout(2000)
+
+    // Should stay on confirm page (NOT redirected to /login)
+    await expect(page).toHaveURL(/\/confirm/)
+
+    // Should NOT have navigated to login
+    expect(page.url()).not.toMatch(/\/login/)
+  })
+})

--- a/tests/unit/composables/api/services/AuthService.test.ts
+++ b/tests/unit/composables/api/services/AuthService.test.ts
@@ -35,6 +35,7 @@ const mockResetUserPassword = vi.fn()
 const mockLogin = vi.fn()
 const mockRegister = vi.fn()
 const mockSendPasswordReset = vi.fn()
+const mockConfirmPasswordReset = vi.fn()
 const mockVerifyEmail = vi.fn()
 const mockLoginWithToken = vi.fn()
 
@@ -47,7 +48,7 @@ vi.mock('~/composables/api/repositories/AuthRepository', () => ({
     logout: vi.fn(),
     refreshToken: vi.fn(),
     sendPasswordReset: mockSendPasswordReset,
-    confirmPasswordReset: vi.fn(),
+    confirmPasswordReset: mockConfirmPasswordReset,
     verifyEmail: mockVerifyEmail,
     loginWithToken: mockLoginWithToken
   }))
@@ -162,6 +163,26 @@ describe('AuthService', () => {
 
       expect(mockSendPasswordReset).toHaveBeenCalledWith('a@b.com')
       expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('confirmPasswordReset', () => {
+    it('should delegate to AuthRepository.confirmPasswordReset', async () => {
+      const mockResponse = { message: 'Password reset confirmed' }
+      mockConfirmPasswordReset.mockResolvedValue(mockResponse)
+
+      const result = await service.confirmPasswordReset('reset-token', 'newPass123')
+
+      expect(mockConfirmPasswordReset).toHaveBeenCalledWith('reset-token', 'newPass123')
+      expect(result).toEqual(mockResponse)
+    })
+
+    it('should propagate rejection from repository', async () => {
+      mockConfirmPasswordReset.mockRejectedValue(new Error('Invalid token'))
+
+      await expect(service.confirmPasswordReset('bad-token', 'newPass123')).rejects.toThrow(
+        'Invalid token'
+      )
     })
   })
 

--- a/tests/unit/composables/auth/usePasswordReset.test.ts
+++ b/tests/unit/composables/auth/usePasswordReset.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { usePasswordReset } from '~/composables/auth/usePasswordReset'
+
+// Mock useAuth
+const mockSendPasswordReset = vi.fn()
+const mockConfirmPasswordReset = vi.fn()
+
+// Mock useToast
+const mockShowSuccess = vi.fn()
+
+// Mock useErrorHandler
+const mockHandleApiError = vi.fn()
+const mockHandleSilentError = vi.fn()
+
+vi.mock('~/composables/errors/useErrorHandler', () => ({
+  useErrorHandler: () => ({
+    handleApiError: mockHandleApiError,
+    handleSilentError: mockHandleSilentError,
+    normalizeError: vi.fn(),
+    handleError: vi.fn(),
+    handleValidationError: vi.fn()
+  })
+}))
+
+describe('usePasswordReset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockSendPasswordReset.mockResolvedValue(undefined)
+    mockConfirmPasswordReset.mockResolvedValue(undefined)
+
+    global.useAuth = vi.fn(() => ({
+      sendPasswordReset: mockSendPasswordReset,
+      confirmPasswordReset: mockConfirmPasswordReset
+    }))
+
+    global.useToast = vi.fn(() => ({
+      showSuccess: mockShowSuccess,
+      showError: vi.fn(),
+      showWarning: vi.fn(),
+      showInfo: vi.fn(),
+      create: vi.fn(() => Promise.resolve({ present: vi.fn() }))
+    }))
+
+    global.useErrorHandler = vi.fn(() => ({
+      handleApiError: mockHandleApiError,
+      handleSilentError: mockHandleSilentError,
+      normalizeError: vi.fn(),
+      handleError: vi.fn(),
+      handleValidationError: vi.fn()
+    }))
+
+    global.navigateTo = vi.fn()
+  })
+
+  describe('requestReset', () => {
+    it('should call sendPasswordReset with email', async () => {
+      const { requestReset } = usePasswordReset()
+
+      await requestReset('user@example.com')
+
+      expect(mockSendPasswordReset).toHaveBeenCalledWith('user@example.com')
+    })
+
+    it('should return generic success on API success', async () => {
+      const { requestReset } = usePasswordReset()
+
+      const result = await requestReset('user@example.com')
+
+      expect(result).toEqual({ success: true })
+    })
+
+    it('should return generic success on API error ' + '(anti-enumeration)', async () => {
+      mockSendPasswordReset.mockRejectedValue(new Error('User not found'))
+      const { requestReset } = usePasswordReset()
+
+      const result = await requestReset('no-user@example.com')
+
+      expect(result).toEqual({ success: true })
+    })
+
+    it('should call handleSilentError on error', async () => {
+      const error = new Error('Network error')
+      mockSendPasswordReset.mockRejectedValue(error)
+      const { requestReset } = usePasswordReset()
+
+      await requestReset('user@example.com')
+
+      expect(mockHandleSilentError).toHaveBeenCalledWith(error, 'usePasswordReset.requestReset')
+    })
+
+    it('should set loading true during request and false after', async () => {
+      let resolveRequest: () => void
+      mockSendPasswordReset.mockReturnValue(
+        new Promise<void>(resolve => {
+          resolveRequest = resolve
+        })
+      )
+      const { requestReset, loading } = usePasswordReset()
+
+      expect(loading.value).toBe(false)
+
+      const promise = requestReset('user@example.com')
+      expect(loading.value).toBe(true)
+
+      resolveRequest!()
+      await promise
+
+      expect(loading.value).toBe(false)
+    })
+  })
+
+  describe('confirmReset', () => {
+    it('should call confirmPasswordReset with token and password', async () => {
+      const { confirmReset } = usePasswordReset()
+
+      await confirmReset({
+        token: 'reset-token-123',
+        password: 'newPassword1!'
+      })
+
+      expect(mockConfirmPasswordReset).toHaveBeenCalledWith('reset-token-123', 'newPassword1!')
+    })
+
+    it('should show success toast on success', async () => {
+      const { confirmReset } = usePasswordReset()
+
+      await confirmReset({
+        token: 'reset-token-123',
+        password: 'newPassword1!'
+      })
+
+      expect(mockShowSuccess).toHaveBeenCalledWith('auth.passwordReset.successToast')
+    })
+
+    it('should navigate to /login on success', async () => {
+      const { confirmReset } = usePasswordReset()
+
+      await confirmReset({
+        token: 'reset-token-123',
+        password: 'newPassword1!'
+      })
+
+      expect(global.navigateTo).toHaveBeenCalledWith('/login')
+    })
+
+    it('should call handleApiError on error', async () => {
+      const error = new Error('Invalid token')
+      mockConfirmPasswordReset.mockRejectedValue(error)
+      const { confirmReset } = usePasswordReset()
+
+      await confirmReset({
+        token: 'bad-token',
+        password: 'newPassword1!'
+      })
+
+      expect(mockHandleApiError).toHaveBeenCalledWith(error, 'usePasswordReset.confirmReset')
+    })
+
+    it('should NOT navigate on error', async () => {
+      mockConfirmPasswordReset.mockRejectedValue(new Error('Invalid token'))
+      const { confirmReset } = usePasswordReset()
+
+      await confirmReset({
+        token: 'bad-token',
+        password: 'newPassword1!'
+      })
+
+      expect(global.navigateTo).not.toHaveBeenCalled()
+    })
+
+    it('should set loading true during request and false after', async () => {
+      let resolveRequest: () => void
+      mockConfirmPasswordReset.mockReturnValue(
+        new Promise<void>(resolve => {
+          resolveRequest = resolve
+        })
+      )
+      const { confirmReset, loading } = usePasswordReset()
+
+      expect(loading.value).toBe(false)
+
+      const promise = confirmReset({
+        token: 'reset-token-123',
+        password: 'newPassword1!'
+      })
+      expect(loading.value).toBe(true)
+
+      resolveRequest!()
+      await promise
+
+      expect(loading.value).toBe(false)
+    })
+  })
+})

--- a/tests/unit/composables/validation/useFormValidation.test.ts
+++ b/tests/unit/composables/validation/useFormValidation.test.ts
@@ -12,7 +12,9 @@ import {
   createRegisterSchema,
   createProfileSchema,
   createRegisterEmailPasswordSchema,
-  createProfileEditSchema
+  createProfileEditSchema,
+  createResetPasswordRequestSchema,
+  createResetPasswordConfirmSchema
 } from '~/composables/validation/useFormValidation'
 
 describe('useFormValidation', () => {
@@ -501,6 +503,26 @@ describe('useFormValidation', () => {
       }
     })
 
+    it('createResetPasswordRequestSchema uses translator', () => {
+      const schema = createResetPasswordRequestSchema(stubT)
+      const result = schema.safeParse({ email: '' })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
+      }
+    })
+
+    it('createResetPasswordConfirmSchema uses translator', () => {
+      const schema = createResetPasswordConfirmSchema(stubT)
+      const result = schema.safeParse({ password: '', confirmPassword: '' })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const msgs = result.error.issues.map(i => i.message)
+        expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
+      }
+    })
+
     it('createProfileEditSchema uses translator', () => {
       const schema = createProfileEditSchema(stubT)
       const result = schema.safeParse({ name: '', city: '', country: '' })
@@ -509,6 +531,72 @@ describe('useFormValidation', () => {
         const msgs = result.error.issues.map(i => i.message)
         expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
       }
+    })
+  })
+
+  describe('resetPasswordRequestSchema', () => {
+    const stubT = (k: string, p?: Record<string, unknown>) => `T:${k}:${JSON.stringify(p ?? {})}`
+
+    it('should accept valid email', () => {
+      const schema = createResetPasswordRequestSchema(stubT)
+      const result = schema.safeParse({ email: 'test@example.com' })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject invalid email', () => {
+      const schema = createResetPasswordRequestSchema(stubT)
+      const result = schema.safeParse({ email: 'not-an-email' })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject empty email', () => {
+      const schema = createResetPasswordRequestSchema(stubT)
+      const result = schema.safeParse({ email: '' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('resetPasswordConfirmSchema', () => {
+    const stubT = (k: string, p?: Record<string, unknown>) => `T:${k}:${JSON.stringify(p ?? {})}`
+
+    it('should accept matching passwords >= 8 chars', () => {
+      const schema = createResetPasswordConfirmSchema(stubT)
+      const result = schema.safeParse({
+        password: 'password123',
+        confirmPassword: 'password123'
+      })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject short passwords', () => {
+      const schema = createResetPasswordConfirmSchema(stubT)
+      const result = schema.safeParse({
+        password: 'short',
+        confirmPassword: 'short'
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject mismatched passwords', () => {
+      const schema = createResetPasswordConfirmSchema(stubT)
+      const result = schema.safeParse({
+        password: 'password123',
+        confirmPassword: 'different123'
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const paths = result.error.issues.map(i => i.path.join('.'))
+        expect(paths).toContain('confirmPassword')
+      }
+    })
+
+    it('should reject empty passwords', () => {
+      const schema = createResetPasswordConfirmSchema(stubT)
+      const result = schema.safeParse({
+        password: '',
+        confirmPassword: ''
+      })
+      expect(result.success).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Add password reset request page (`/auth/reset-password`) and confirm page (`/auth/reset-password/confirm?token=...`) with public layout and guest middleware
- Add `AuthService.confirmPasswordReset` and `useAuth.confirmPasswordReset` + `sendRegisterToken` facade wrappers
- Add `usePasswordReset` composable with anti-enumeration on request (silent errors) and API error handling + toast + navigation on confirm
- Add `PasswordResetRequestForm` and `PasswordResetConfirmForm` components using Zod validation schemas
- Add "Forgot password?" link to login page
- Fix `verify-token.vue`: remove `new AuthService()` anti-pattern, replace TODO with success toast, route through `useAuth` and `useErrorHandler`
- Add `auth.passwordReset.*` i18n keys to all 5 locales (en-US, de-DE, es-ES, fr-FR, pt-BR)
- Add unit tests for service, schemas, and composable (80 tests total); add Playwright e2e spec

## Test plan

- [x] `npx vitest run` — 588 tests pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run generate` — builds successfully
- [ ] Manual: click "Forgot password?" on `/login` → navigate to request page
- [ ] Manual: submit email → see generic success message
- [ ] Manual: visit `/auth/reset-password/confirm?token=test` → see confirm form
- [ ] Manual: visit `/auth/reset-password/confirm` (no token) → see error + link back
- [ ] Manual: "Resend code" on `/verify-token` → success toast

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full password reset flow: request by email and confirm new password via token, with inline validation, loading spinners, success toasts, invalid-token messaging and locale-aware navigation.
  * "Forgot Password" link added to the login page.
  * Localization added for the password reset flow (en, de, es, fr, pt-BR).

* **Tests**
  * Added unit and end-to-end tests covering request, confirmation, validation, success toast, invalid-token and backend error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->