### PR TITLE
chore: remove unused ionic-vue-router dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@vueuse/core": "^13.5.0",
         "@vueuse/nuxt": "^13.5.0",
         "dompurify": "^3.2.7",
-        "ionic-vue-router": "^8.2.8",
         "isomorphic-dompurify": "^2.28.0",
         "marked": "^16.3.0",
         "nuxt": "^4.0.0",
@@ -13453,15 +13452,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/ionic-vue-router": {
-      "version": "8.2.8",
-      "resolved": "https://registry.npmjs.org/ionic-vue-router/-/ionic-vue-router-8.2.8.tgz",
-      "integrity": "sha512-jxyD/Po61Di/8jEdna3LgDTRppFf42+4V9lZkZgFoGzixNn12giN8WJHWLUMTyTuXIIz9Ci85n7NG2qtHk2gbg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@ionic/vue": "*"
       }
     },
     "node_modules/ionicons": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@vueuse/core": "^13.5.0",
     "@vueuse/nuxt": "^13.5.0",
     "dompurify": "^3.2.7",
-    "ionic-vue-router": "^8.2.8",
     "isomorphic-dompurify": "^2.28.0",
     "marked": "^16.3.0",
     "nuxt": "^4.0.0",


### PR DESCRIPTION
## Summary

- Remove orphan `ionic-vue-router@^8.2.8` from `package.json` (line 43)
- Regenerate `package-lock.json` via `npm install` (removes top-level declaration and `node_modules/ionic-vue-router` block)
- The active router `@ionic/vue-router@^8.6.4` remains untouched

**Note**: The `package-lock.json` diff shows 10 deleted lines — the top-level declaration plus the full `node_modules/ionic-vue-router` block. This is expected and purely subtractive.

## Verification

All CI-parity gates pass locally:
- ✅ `npm ls ionic-vue-router` → empty
- ✅ `npm run lint`
- ✅ `npm run format:check`
- ✅ `npm run typecheck`
- ✅ `npm test` (566/566 passed)
- ✅ `npm run build`
- ✅ `git diff` limited to `package.json` + `package-lock.json`

Closes #27

Generated by flow_ai workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies for improved build performance and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->