### PR TITLE
test: expand unit tests for API and auth edge cases

### DIFF
--- a/tests/setup/global.d.ts
+++ b/tests/setup/global.d.ts
@@ -29,6 +29,10 @@ declare global {
   const useRoute: () => RouteLocationNormalizedLoaded
   const navigateTo: (to: string | { path: string }) => Promise<void>
   const $fetch: typeof import('ofetch').$fetch
+  const createError: (o: {
+    statusCode: number
+    statusMessage: string
+  }) => Error & { statusCode: number; statusMessage: string }
 
   // Pinia functions (from real Pinia)
   const defineStore: (typeof import('pinia'))['defineStore']

--- a/tests/setup/test-setup.ts
+++ b/tests/setup/test-setup.ts
@@ -288,6 +288,10 @@ config.global.stubs = {
   }
 }
 
+// Mock Nuxt createError
+global.createError = (o: { statusCode: number; statusMessage: string }) =>
+  Object.assign(new Error(o.statusMessage), o)
+
 // Setup Pinia for each test
 beforeEach(() => {
   const pinia = createPinia()

--- a/tests/unit/composables/useApi.test.ts
+++ b/tests/unit/composables/useApi.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAuthStore } from '~/stores/auth'
+
+// Mock useErrorHandler BEFORE importing useApi
+const mockHandleSilentError = vi.fn()
+vi.mock('~/composables/errors/useErrorHandler', () => ({
+  useErrorHandler: () => ({
+    handleSilentError: mockHandleSilentError,
+    handleError: vi.fn(),
+    normalizeError: vi.fn(),
+    handleApiError: vi.fn(),
+    handleValidationError: vi.fn()
+  })
+}))
+
+// Capture $fetch.create config
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let captured: Record<string, any> = {}
+const originalFetch = global.$fetch
+const originalUseAuthStore = global.useAuthStore
+
+describe('useApi', () => {
+  let store: ReturnType<typeof useAuthStore>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    captured = {}
+    // Override $fetch with a create spy that captures config
+    global.$fetch = Object.assign(vi.fn(), {
+      create: (opts: Record<string, unknown>) => {
+        Object.assign(captured, opts)
+        return vi.fn()
+      }
+    }) as unknown as typeof global.$fetch
+    setActivePinia(createPinia())
+    store = useAuthStore()
+    // Override global useAuthStore so useApi's onRequest
+    // resolves to the real Pinia store instance
+    global.useAuthStore = (() => store) as typeof global.useAuthStore
+  })
+
+  afterEach(() => {
+    global.$fetch = originalFetch
+    global.useAuthStore = originalUseAuthStore
+  })
+
+  // Helper: lazily import and invoke useApi to capture config
+  const loadUseApi = async () => {
+    const mod = await import('~/composables/useApi')
+    return mod.useApi()
+  }
+
+  describe('config', () => {
+    it('sets timeout to API_TIMEOUT (10000)', async () => {
+      await loadUseApi()
+      expect(captured.timeout).toBe(10000)
+    })
+
+    it('sets retry to 2', async () => {
+      await loadUseApi()
+      expect(captured.retry).toBe(2)
+    })
+  })
+
+  describe('onRequest', () => {
+    it('sets Bearer header when token is present', async () => {
+      store.setToken('abc')
+      await loadUseApi()
+      const headers = new Headers()
+      const options = { headers }
+      captured.onRequest({ options })
+      expect(options.headers.get('Authorization')).toBe('Bearer abc')
+    })
+
+    it('does not set Authorization when token is null', async () => {
+      await loadUseApi()
+      // initializeAuth is a no-op when storage is empty,
+      // so token stays null after the interceptor runs
+      const headers = new Headers()
+      const options = { headers }
+      captured.onRequest({ options })
+      expect(options.headers.get('Authorization')).toBeNull()
+    })
+
+    it('calls initializeAuth when client and no token', async () => {
+      await loadUseApi()
+      const spy = vi.spyOn(store, 'initializeAuth')
+      const headers = new Headers()
+      const options = { headers }
+      captured.onRequest({ options })
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('strips Content-Type for FormData body', async () => {
+      store.setToken('tok')
+      await loadUseApi()
+      const headers = new Headers({
+        'Content-Type': 'application/json'
+      })
+      const options = { headers, body: new FormData() }
+      captured.onRequest({ options })
+      expect(options.headers.get('Content-Type')).toBeNull()
+    })
+
+    it('preserves Content-Type for JSON body', async () => {
+      store.setToken('tok')
+      await loadUseApi()
+      const headers = new Headers({
+        'Content-Type': 'application/json'
+      })
+      const options = { headers, body: { foo: 'bar' } }
+      captured.onRequest({ options })
+      expect(options.headers.get('Content-Type')).toBe('application/json')
+    })
+  })
+
+  describe('onRequestError', () => {
+    it('calls handleSilentError with error and context', async () => {
+      await loadUseApi()
+      const err = new Error('net fail')
+      try {
+        captured.onRequestError({ error: err })
+      } catch {
+        // expected throw
+      }
+      expect(mockHandleSilentError).toHaveBeenCalledWith(err, 'useApi.request')
+    })
+
+    it('throws createError with statusCode 500', async () => {
+      await loadUseApi()
+      const err = new Error('net fail')
+      expect(() => captured.onRequestError({ error: err })).toThrow()
+      try {
+        captured.onRequestError({ error: err })
+      } catch (thrown: unknown) {
+        const e = thrown as Error & {
+          statusCode: number
+          statusMessage: string
+        }
+        expect(e.statusCode).toBe(500)
+        expect(e.statusMessage).toContain('Network connection error')
+      }
+    })
+  })
+
+  describe('onResponseError', () => {
+    it('does not logout or navigate on non-401', async () => {
+      await loadUseApi()
+      const logoutSpy = vi.spyOn(store, 'logout')
+      captured.onResponseError({ response: { status: 403 } })
+      expect(logoutSpy).not.toHaveBeenCalled()
+      expect(navigateTo).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/composables/useApi.test.ts
+++ b/tests/unit/composables/useApi.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from '~/stores/auth'
+import { API_TIMEOUT } from '~/utils/constants'
 
 // Mock useErrorHandler BEFORE importing useApi
 const mockHandleSilentError = vi.fn()
@@ -52,9 +53,9 @@ describe('useApi', () => {
   }
 
   describe('config', () => {
-    it('sets timeout to API_TIMEOUT (10000)', async () => {
+    it('sets timeout to API_TIMEOUT', async () => {
       await loadUseApi()
-      expect(captured.timeout).toBe(10000)
+      expect(captured.timeout).toBe(API_TIMEOUT)
     })
 
     it('sets retry to 2', async () => {
@@ -130,17 +131,19 @@ describe('useApi', () => {
     it('throws createError with statusCode 500', async () => {
       await loadUseApi()
       const err = new Error('net fail')
-      expect(() => captured.onRequestError({ error: err })).toThrow()
+      let thrown: unknown
       try {
         captured.onRequestError({ error: err })
-      } catch (thrown: unknown) {
-        const e = thrown as Error & {
-          statusCode: number
-          statusMessage: string
-        }
-        expect(e.statusCode).toBe(500)
-        expect(e.statusMessage).toContain('Network connection error')
+      } catch (e) {
+        thrown = e
       }
+      expect(thrown).toBeDefined()
+      const e = thrown as Error & {
+        statusCode: number
+        statusMessage: string
+      }
+      expect(e.statusCode).toBe(500)
+      expect(e.statusMessage).toContain('Network connection error')
     })
   })
 

--- a/tests/unit/composables/validation/useFormValidation.test.ts
+++ b/tests/unit/composables/validation/useFormValidation.test.ts
@@ -12,8 +12,11 @@ import {
   createRegisterSchema,
   createProfileSchema,
   createRegisterEmailPasswordSchema,
-  createProfileEditSchema
+  createProfileEditSchema,
+  createCompanyEditSchema,
+  createFallbackTranslator
 } from '~/composables/validation/useFormValidation'
+import type { TranslateFn } from '~/composables/validation/useFormValidation'
 
 describe('useFormValidation', () => {
   describe('validationSchemas', () => {
@@ -508,6 +511,81 @@ describe('useFormValidation', () => {
       if (!result.success) {
         const msgs = result.error.issues.map(i => i.message)
         expect(msgs.some(m => m.startsWith('T:'))).toBe(true)
+      }
+    })
+  })
+
+  describe('factory and composition gaps', () => {
+    it('translator returning undefined falls back to Zod defaults', () => {
+      const brokenT = (() => undefined) as unknown as TranslateFn
+      const schema = createLoginSchema(brokenT)
+      const result = schema.safeParse({
+        email: 'not-an-email',
+        password: 'x'
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        // Zod uses its own English defaults when message
+        // is undefined
+        const emailIssue = result.error.issues.find(i => i.path[0] === 'email')
+        expect(emailIssue).toBeDefined()
+        expect(emailIssue!.message).toBeTruthy()
+      }
+    })
+
+    it('createFallbackTranslator produces English messages', () => {
+      const t = createFallbackTranslator()
+      const schema = createLoginSchema(t)
+      const result = schema.safeParse({
+        email: 'bad',
+        password: 'x'
+      })
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        const emailMsg = result.error.issues.find(i => i.path[0] === 'email')?.message
+        expect(emailMsg).toBe('Please enter a valid email address')
+      }
+    })
+
+    it('login and register reject not-an-email ' + 'with identical messages', () => {
+      const t = createFallbackTranslator()
+      const loginS = createLoginSchema(t)
+      const registerS = createRegisterSchema(t)
+      const loginResult = loginS.safeParse({
+        email: 'not-an-email',
+        password: '12345678'
+      })
+      const registerResult = registerS.safeParse({
+        name: 'a',
+        email: 'not-an-email',
+        password: '12345678',
+        confirmPassword: '12345678'
+      })
+      expect(loginResult.success).toBe(false)
+      expect(registerResult.success).toBe(false)
+      if (!loginResult.success && !registerResult.success) {
+        const loginEmailMsg = loginResult.error.issues.find(i => i.path[0] === 'email')?.message
+        const regEmailMsg = registerResult.error.issues.find(i => i.path[0] === 'email')?.message
+        expect(loginEmailMsg).toBe(regEmailMsg)
+      }
+    })
+
+    it('profile and company emit error on missing name', () => {
+      const t = createFallbackTranslator()
+      const profileS = createProfileSchema(t)
+      const companyS = createCompanyEditSchema(t)
+      const profileResult = profileS.safeParse({
+        name: '',
+        email: 'a@b.c'
+      })
+      const companyResult = companyS.safeParse({ name: '' })
+      expect(profileResult.success).toBe(false)
+      expect(companyResult.success).toBe(false)
+      if (!profileResult.success && !companyResult.success) {
+        const profileNameErr = profileResult.error.issues.find(i => i.path[0] === 'name')
+        const companyNameErr = companyResult.error.issues.find(i => i.path[0] === 'name')
+        expect(profileNameErr).toBeDefined()
+        expect(companyNameErr).toBeDefined()
       }
     })
   })

--- a/tests/unit/stores/auth.test.ts
+++ b/tests/unit/stores/auth.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, beforeEach, vi, afterEach, beforeAll, afterAll } 
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from '~/stores/auth'
 import type { ProfileResponse } from '~/composables/api/repositories/ProfileRepository'
+
+type MockProfileRepo =
+  typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
+
 vi.mock('~/composables/api/repositories/ProfileRepository', () => ({
   ProfileRepository: vi.fn().mockImplementation(() => ({
     getCurrentProfile: vi.fn(),
@@ -14,6 +18,28 @@ vi.mock('~/composables/useApiEndpoints', () => ({
     profilesSwitchCompany: '/profiles/switch-company'
   })
 }))
+const makeActiveCompany = (company: {
+  _id?: string
+  id?: string
+  name: string
+}): ProfileResponse['active_company'] => ({
+  company,
+  metrics: {},
+  tasks: [],
+  devices: [],
+  spaces: [],
+  admins: [],
+  managers: [],
+  operators: []
+})
+
+const makeProfileResponse = (over: Partial<ProfileResponse> = {}): ProfileResponse => ({
+  user: { _id: 'u1', email: 'a@b.c', balance: 0 },
+  active_company: null,
+  other_companies: [],
+  ...over
+})
+
 const mockStorage: Record<string, string> = {}
 const originalUseStorage = global.useStorage
 beforeAll(() => {
@@ -70,33 +96,18 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
   })
   describe('Existing behavior preservation', () => {
     it('should not auto-select when active_company exists', async () => {
-      const profileWithActiveCompany: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 100
-        },
-        active_company: {
-          company: { _id: 'comp1', name: 'Active Co' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        },
+      const profileWithActiveCompany = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 100 },
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'Active Co' }),
         other_companies: [
           { _id: 'comp2', name: 'Other Co 1' },
           { _id: 'comp3', name: 'Other Co 2' }
         ]
-      }
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithActiveCompany)
       mockSwitchCompany = vi.fn()
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -114,21 +125,13 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       })
     })
     it('should handle profile with no companies at all', async () => {
-      const profileWithNoCompanies: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 50
-        },
-        active_company: null,
-        other_companies: []
-      }
+      const profileWithNoCompanies = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 50 }
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithNoCompanies)
       mockSwitchCompany = vi.fn()
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -144,37 +147,21 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
   })
   describe('Auto-selection functionality', () => {
     it('should auto-select first company when no active_company exists', async () => {
-      const profileWithoutActiveCompany: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 75
-        },
-        active_company: null,
+      const profileWithoutActiveCompany = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 75 },
         other_companies: [
           { _id: 'comp1', name: 'First Co' },
           { _id: 'comp2', name: 'Second Co' }
         ]
-      }
-      const updatedProfile: ProfileResponse = {
+      })
+      const updatedProfile = makeProfileResponse({
         ...profileWithoutActiveCompany,
-        active_company: {
-          company: { _id: 'comp1', name: 'First Co' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        }
-      }
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'First Co' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -199,37 +186,21 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       })
     })
     it('should handle companies with id field instead of _id', async () => {
-      const profileWithIdField: ProfileResponse = {
-        user: {
-          id: 'user1',
-          email: 'test@example.com',
-          balance: 60
-        },
-        active_company: null,
+      const profileWithIdField = makeProfileResponse({
+        user: { id: 'user1', email: 'test@example.com', balance: 60 },
         other_companies: [
           { id: 'comp1', name: 'Company with id' },
           { _id: 'comp2', name: 'Company with _id' }
         ]
-      }
-      const updatedProfile: ProfileResponse = {
+      })
+      const updatedProfile = makeProfileResponse({
         ...profileWithIdField,
-        active_company: {
-          company: { id: 'comp1', name: 'Company with id' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        }
-      }
+        active_company: makeActiveCompany({ id: 'comp1', name: 'Company with id' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithIdField)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -242,24 +213,17 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       })
     })
     it('should use local fallback when company has no valid ID', async () => {
-      const profileWithInvalidId: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 80
-        },
-        active_company: null,
+      const profileWithInvalidId = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 80 },
         other_companies: [
           { name: 'Company without ID' } as { name: string },
           { _id: 'comp2', name: 'Valid Company' }
         ]
-      }
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithInvalidId)
       mockSwitchCompany = vi.fn()
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -279,28 +243,14 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
   describe('Retry mechanism', () => {
     it('should retry switchCompany on failure', async () => {
       vi.useFakeTimers()
-      const profileWithoutActiveCompany: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 90
-        },
-        active_company: null,
+      const profileWithoutActiveCompany = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 90 },
         other_companies: [{ _id: 'comp1', name: 'First Co' }]
-      }
-      const updatedProfile: ProfileResponse = {
+      })
+      const updatedProfile = makeProfileResponse({
         ...profileWithoutActiveCompany,
-        active_company: {
-          company: { _id: 'comp1', name: 'First Co' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        }
-      }
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'First Co' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi
@@ -309,9 +259,7 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         .mockRejectedValueOnce(new Error('Timeout'))
         .mockRejectedValueOnce(new Error('Retry'))
         .mockResolvedValueOnce(updatedProfile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -332,24 +280,17 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
     })
     it('should fall back to local selection after all retries fail', async () => {
       vi.useFakeTimers()
-      const profileWithoutActiveCompany: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 95
-        },
-        active_company: null,
+      const profileWithoutActiveCompany = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 95 },
         other_companies: [
           { _id: 'comp1', name: 'First Co' },
           { _id: 'comp2', name: 'Second Co' }
         ]
-      }
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockRejectedValue(new Error('Persistent API failure'))
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -381,21 +322,14 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
     })
     it('should use correct fixed retry delays', async () => {
       vi.useFakeTimers()
-      const profileWithoutActiveCompany: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 85
-        },
-        active_company: null,
+      const profileWithoutActiveCompany = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 85 },
         other_companies: [{ _id: 'comp1', name: 'Test Co' }]
-      }
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockRejectedValue(new Error('Test error'))
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -411,29 +345,13 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
   })
   describe('State management', () => {
     it('should update lastProfileFetch after successful fetch', async () => {
-      const profile: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 100
-        },
-        active_company: {
-          company: { _id: 'comp1', name: 'Test Co' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        },
-        other_companies: []
-      }
+      const profile = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 100 },
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'Test Co' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: vi.fn()
       }))
@@ -444,34 +362,18 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       expect(mockStorage['auth_last_profile_fetch']).toBeDefined()
     })
     it('should persist state to storage after auto-selection', async () => {
-      const profileWithoutActiveCompany: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 70
-        },
-        active_company: null,
+      const profileWithoutActiveCompany = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 70 },
         other_companies: [{ _id: 'comp1', name: 'Selected Co' }]
-      }
-      const updatedProfile: ProfileResponse = {
+      })
+      const updatedProfile = makeProfileResponse({
         ...profileWithoutActiveCompany,
-        active_company: {
-          company: { _id: 'comp1', name: 'Selected Co' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        }
-      }
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'Selected Co' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profileWithoutActiveCompany)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -499,34 +401,18 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       expect(storedOtherCompanies).toEqual(otherComps)
     })
     it('should return correct data structure from fetchProfile', async () => {
-      const profile: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 65
-        },
-        active_company: null,
+      const profile = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 65 },
         other_companies: [{ _id: 'comp1', name: 'Auto Selected' }]
-      }
-      const updatedProfile: ProfileResponse = {
+      })
+      const updatedProfile = makeProfileResponse({
         ...profile,
-        active_company: {
-          company: { _id: 'comp1', name: 'Auto Selected' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        }
-      }
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'Auto Selected' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -556,30 +442,21 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
     it('should throw error when fetchProfile fails completely', async () => {
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockRejectedValue(new Error('API Error'))
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: vi.fn()
       }))
       await expect(store.fetchProfile()).rejects.toThrow('API Error')
     })
     it('should handle edge case of empty other_companies array', async () => {
-      const profile: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 55
-        },
-        active_company: null,
+      const profile = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 55 },
         other_companies: null as unknown as []
-      }
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       mockSwitchCompany = vi.fn()
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -589,34 +466,19 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       expect(store.otherCompanies).toEqual([])
     })
     it('should handle undefined active_company gracefully', async () => {
-      const profile: ProfileResponse = {
-        user: {
-          _id: 'user1',
-          email: 'test@example.com',
-          balance: 45
-        },
+      const profile = makeProfileResponse({
+        user: { _id: 'user1', email: 'test@example.com', balance: 45 },
         active_company: undefined as unknown as null,
         other_companies: [{ _id: 'comp1', name: 'Company 1' }]
-      }
-      const updatedProfile: ProfileResponse = {
+      })
+      const updatedProfile = makeProfileResponse({
         ...profile,
-        active_company: {
-          company: { _id: 'comp1', name: 'Company 1' },
-          metrics: {},
-          tasks: [],
-          devices: [],
-          spaces: [],
-          admins: [],
-          managers: [],
-          operators: []
-        }
-      }
+        active_company: makeActiveCompany({ _id: 'comp1', name: 'Company 1' })
+      })
       const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
       mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
       mockSwitchCompany = vi.fn().mockResolvedValue(updatedProfile)
-      ;(
-        ProfileRepository as typeof import('~/composables/api/repositories/ProfileRepository').ProfileRepository
-      ).mockImplementation(() => ({
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
         getCurrentProfile: mockGetCurrentProfile,
         switchCompany: mockSwitchCompany
       }))
@@ -627,6 +489,159 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         id: 'comp1',
         name: 'Company 1'
       })
+    })
+  })
+  describe('fetchProfile edge cases', () => {
+    it('concurrent fetchProfile calls getCurrentProfile once', async () => {
+      const profile = makeProfileResponse({
+        user: { _id: 'user1', email: 'a@b.c', balance: 10 },
+        active_company: makeActiveCompany({ _id: 'c1', name: 'Co' })
+      })
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+        getCurrentProfile: mockGetCurrentProfile,
+        switchCompany: vi.fn()
+      }))
+      // Both calls start synchronously; the second should
+      // reuse the in-flight promise
+      const p1 = store.fetchProfile()
+      const p2 = store.fetchProfile()
+      const r1 = await p1
+      await p2
+      expect(mockGetCurrentProfile).toHaveBeenCalledTimes(1)
+      expect(r1.user).toEqual({
+        _id: 'user1',
+        id: 'user1',
+        email: 'a@b.c',
+        balance: 10
+      })
+    })
+
+    it(
+      'profileFetchPromise cleared after rejection — ' +
+        'second call fires fresh getCurrentProfile',
+      async () => {
+        const { ProfileRepository } = await import(
+          '~/composables/api/repositories/ProfileRepository'
+        )
+        const successProfile = makeProfileResponse({
+          user: { _id: 'u2', email: 'x@y.z', balance: 5 },
+          active_company: makeActiveCompany({ _id: 'c2', name: 'C2' })
+        })
+        mockGetCurrentProfile = vi
+          .fn()
+          .mockRejectedValueOnce(new Error('boom'))
+          .mockResolvedValueOnce(successProfile)
+        ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+          getCurrentProfile: mockGetCurrentProfile,
+          switchCompany: vi.fn()
+        }))
+        await expect(store.fetchProfile()).rejects.toThrow('boom')
+        const result = await store.fetchProfile()
+        expect(mockGetCurrentProfile).toHaveBeenCalledTimes(2)
+        expect(result.user).toEqual({
+          _id: 'u2',
+          id: 'u2',
+          email: 'x@y.z',
+          balance: 5
+        })
+      }
+    )
+
+    it(
+      'switchCompany rejected with string "Bad Gateway" ' + '— fallback sets first company',
+      async () => {
+        vi.useFakeTimers()
+        const profile = makeProfileResponse({
+          user: { _id: 'u3', email: 'f@g.h', balance: 0 },
+          other_companies: [
+            { _id: 'cx', name: 'FallbackCo' },
+            { _id: 'cy', name: 'Other' }
+          ]
+        })
+        const { ProfileRepository } = await import(
+          '~/composables/api/repositories/ProfileRepository'
+        )
+        mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
+        mockSwitchCompany = vi.fn().mockRejectedValue('Bad Gateway')
+        ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+          getCurrentProfile: mockGetCurrentProfile,
+          switchCompany: mockSwitchCompany
+        }))
+        const fetchPromise = store.fetchProfile()
+        await vi.runOnlyPendingTimersAsync()
+        await vi.advanceTimersByTimeAsync(1000)
+        await vi.advanceTimersByTimeAsync(1000)
+        await vi.advanceTimersByTimeAsync(1000)
+        await fetchPromise
+        expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
+        expect(store.activeCompany).toEqual({
+          _id: 'cx',
+          id: 'cx',
+          name: 'FallbackCo'
+        })
+        vi.useRealTimers()
+      }
+    )
+
+    it(
+      'switchCompany rejected with fetchError-like object ' + '— fallback sets first company',
+      async () => {
+        vi.useFakeTimers()
+        const profile = makeProfileResponse({
+          user: { _id: 'u4', email: 'h@i.j', balance: 0 },
+          other_companies: [{ _id: 'cz', name: 'FBCo' }]
+        })
+        const { ProfileRepository } = await import(
+          '~/composables/api/repositories/ProfileRepository'
+        )
+        mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
+        mockSwitchCompany = vi.fn().mockRejectedValue({
+          statusCode: 502,
+          data: { detail: 'forbidden' }
+        })
+        ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+          getCurrentProfile: mockGetCurrentProfile,
+          switchCompany: mockSwitchCompany
+        }))
+        const fetchPromise = store.fetchProfile()
+        await vi.runOnlyPendingTimersAsync()
+        await vi.advanceTimersByTimeAsync(1000)
+        await vi.advanceTimersByTimeAsync(1000)
+        await vi.advanceTimersByTimeAsync(1000)
+        await fetchPromise
+        expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
+        expect(store.activeCompany).toEqual({
+          _id: 'cz',
+          id: 'cz',
+          name: 'FBCo'
+        })
+        vi.useRealTimers()
+      }
+    )
+
+    it('retry exhaustion preserves token', async () => {
+      vi.useFakeTimers()
+      const profile = makeProfileResponse({
+        user: { _id: 'u5', email: 'k@l.m', balance: 0 },
+        other_companies: [{ _id: 'cw', name: 'KeepToken' }]
+      })
+      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
+      mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
+      mockSwitchCompany = vi.fn().mockRejectedValue(new Error('fail'))
+      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+        getCurrentProfile: mockGetCurrentProfile,
+        switchCompany: mockSwitchCompany
+      }))
+      const fetchPromise = store.fetchProfile()
+      await vi.runOnlyPendingTimersAsync()
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      await vi.advanceTimersByTimeAsync(1000)
+      await fetchPromise
+      expect(store.token).toBe('test-token')
+      vi.useRealTimers()
     })
   })
 })

--- a/tests/unit/stores/auth.test.ts
+++ b/tests/unit/stores/auth.test.ts
@@ -553,35 +553,38 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       'switchCompany rejected with string "Bad Gateway" ' + '— fallback sets first company',
       async () => {
         vi.useFakeTimers()
-        const profile = makeProfileResponse({
-          user: { _id: 'u3', email: 'f@g.h', balance: 0 },
-          other_companies: [
-            { _id: 'cx', name: 'FallbackCo' },
-            { _id: 'cy', name: 'Other' }
-          ]
-        })
-        const { ProfileRepository } = await import(
-          '~/composables/api/repositories/ProfileRepository'
-        )
-        mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
-        mockSwitchCompany = vi.fn().mockRejectedValue('Bad Gateway')
-        ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
-          getCurrentProfile: mockGetCurrentProfile,
-          switchCompany: mockSwitchCompany
-        }))
-        const fetchPromise = store.fetchProfile()
-        await vi.runOnlyPendingTimersAsync()
-        await vi.advanceTimersByTimeAsync(1000)
-        await vi.advanceTimersByTimeAsync(1000)
-        await vi.advanceTimersByTimeAsync(1000)
-        await fetchPromise
-        expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
-        expect(store.activeCompany).toEqual({
-          _id: 'cx',
-          id: 'cx',
-          name: 'FallbackCo'
-        })
-        vi.useRealTimers()
+        try {
+          const profile = makeProfileResponse({
+            user: { _id: 'u3', email: 'f@g.h', balance: 0 },
+            other_companies: [
+              { _id: 'cx', name: 'FallbackCo' },
+              { _id: 'cy', name: 'Other' }
+            ]
+          })
+          const { ProfileRepository } = await import(
+            '~/composables/api/repositories/ProfileRepository'
+          )
+          mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
+          mockSwitchCompany = vi.fn().mockRejectedValue('Bad Gateway')
+          ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+            getCurrentProfile: mockGetCurrentProfile,
+            switchCompany: mockSwitchCompany
+          }))
+          const fetchPromise = store.fetchProfile()
+          await vi.runOnlyPendingTimersAsync()
+          await vi.advanceTimersByTimeAsync(1000)
+          await vi.advanceTimersByTimeAsync(1000)
+          await vi.advanceTimersByTimeAsync(1000)
+          await fetchPromise
+          expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
+          expect(store.activeCompany).toEqual({
+            _id: 'cx',
+            id: 'cx',
+            name: 'FallbackCo'
+          })
+        } finally {
+          vi.useRealTimers()
+        }
       }
     )
 
@@ -589,18 +592,53 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
       'switchCompany rejected with fetchError-like object ' + '— fallback sets first company',
       async () => {
         vi.useFakeTimers()
+        try {
+          const profile = makeProfileResponse({
+            user: { _id: 'u4', email: 'h@i.j', balance: 0 },
+            other_companies: [{ _id: 'cz', name: 'FBCo' }]
+          })
+          const { ProfileRepository } = await import(
+            '~/composables/api/repositories/ProfileRepository'
+          )
+          mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
+          mockSwitchCompany = vi.fn().mockRejectedValue({
+            statusCode: 502,
+            data: { detail: 'forbidden' }
+          })
+          ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
+            getCurrentProfile: mockGetCurrentProfile,
+            switchCompany: mockSwitchCompany
+          }))
+          const fetchPromise = store.fetchProfile()
+          await vi.runOnlyPendingTimersAsync()
+          await vi.advanceTimersByTimeAsync(1000)
+          await vi.advanceTimersByTimeAsync(1000)
+          await vi.advanceTimersByTimeAsync(1000)
+          await fetchPromise
+          expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
+          expect(store.activeCompany).toEqual({
+            _id: 'cz',
+            id: 'cz',
+            name: 'FBCo'
+          })
+        } finally {
+          vi.useRealTimers()
+        }
+      }
+    )
+
+    it('retry exhaustion preserves token', async () => {
+      vi.useFakeTimers()
+      try {
         const profile = makeProfileResponse({
-          user: { _id: 'u4', email: 'h@i.j', balance: 0 },
-          other_companies: [{ _id: 'cz', name: 'FBCo' }]
+          user: { _id: 'u5', email: 'k@l.m', balance: 0 },
+          other_companies: [{ _id: 'cw', name: 'KeepToken' }]
         })
         const { ProfileRepository } = await import(
           '~/composables/api/repositories/ProfileRepository'
         )
         mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
-        mockSwitchCompany = vi.fn().mockRejectedValue({
-          statusCode: 502,
-          data: { detail: 'forbidden' }
-        })
+        mockSwitchCompany = vi.fn().mockRejectedValue(new Error('fail'))
         ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
           getCurrentProfile: mockGetCurrentProfile,
           switchCompany: mockSwitchCompany
@@ -611,37 +649,10 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
         await vi.advanceTimersByTimeAsync(1000)
         await vi.advanceTimersByTimeAsync(1000)
         await fetchPromise
-        expect(mockSwitchCompany).toHaveBeenCalledTimes(4)
-        expect(store.activeCompany).toEqual({
-          _id: 'cz',
-          id: 'cz',
-          name: 'FBCo'
-        })
+        expect(store.token).toBe('test-token')
+      } finally {
         vi.useRealTimers()
       }
-    )
-
-    it('retry exhaustion preserves token', async () => {
-      vi.useFakeTimers()
-      const profile = makeProfileResponse({
-        user: { _id: 'u5', email: 'k@l.m', balance: 0 },
-        other_companies: [{ _id: 'cw', name: 'KeepToken' }]
-      })
-      const { ProfileRepository } = await import('~/composables/api/repositories/ProfileRepository')
-      mockGetCurrentProfile = vi.fn().mockResolvedValue(profile)
-      mockSwitchCompany = vi.fn().mockRejectedValue(new Error('fail'))
-      ;(ProfileRepository as MockProfileRepo).mockImplementation(() => ({
-        getCurrentProfile: mockGetCurrentProfile,
-        switchCompany: mockSwitchCompany
-      }))
-      const fetchPromise = store.fetchProfile()
-      await vi.runOnlyPendingTimersAsync()
-      await vi.advanceTimersByTimeAsync(1000)
-      await vi.advanceTimersByTimeAsync(1000)
-      await vi.advanceTimersByTimeAsync(1000)
-      await fetchPromise
-      expect(store.token).toBe('test-token')
-      vi.useRealTimers()
     })
   })
 })

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -52,10 +52,10 @@ export default defineConfig({
       reportsDirectory: './coverage',
       exclude: ['node_modules/**', 'tests/**', '**/*.config.*', '.nuxt/**', 'dist/**'],
       thresholds: {
-        lines: 25,
+        lines: 27,
         branches: 78,
         functions: 72,
-        statements: 25
+        statements: 27
       }
     }
   },


### PR DESCRIPTION
## Summary

Closes #29

- **T1**: Added `global.createError` shim to `tests/setup/test-setup.ts` and type declaration to `global.d.ts`
- **T2**: Created `tests/unit/composables/useApi.test.ts` — 10 tests covering all three interceptors (`onRequest`, `onRequestError`, `onResponseError`) plus config verification. Zero 401/refresh scenarios per spec.
- **T3**: Extended `tests/unit/stores/auth.test.ts` with `fetchProfile edge cases` describe (5 tests: concurrent dedup, promise cleanup after rejection, string rejection fallback, fetchError-like object fallback, token preservation on retry exhaustion). Extracted `makeProfileResponse` and `makeActiveCompany` helpers; refactored all existing tests to use them. Introduced `MockProfileRepo` type alias to fix line-length violations. File reduced from 633 to 647 LOC (under 720 target).
- **T4**: Extended `tests/unit/composables/validation/useFormValidation.test.ts` with `factory and composition gaps` describe (4 tests: undefined translator → Zod defaults, English fallback messages, shared email fragment identity across login/register, profile/company name error path shape).
- **T5**: Bumped `vitest.config.mjs` coverage thresholds — lines 25→27, statements 25→27 (branches 78, functions 72 unchanged — tight margin to baseline).

## Raw `npm run test:coverage` baseline

```
All files          |   29.34 |    78.91 |   72.52 |   29.34 |
```

- 30 test files, 78 targeted tests (10 + 19 + 49), all green
- `typecheck`, `lint`, `format:check`, `generate` all pass

## Test plan

- [x] `npx vitest run tests/unit/composables/useApi.test.ts tests/unit/stores/auth.test.ts tests/unit/composables/validation/useFormValidation.test.ts --pool=forks --maxWorkers=1` — 78 tests pass
- [x] `npm run test:coverage` — 30 files pass, thresholds met
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run generate` — builds successfully

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced unit coverage for API and validation composables, including request/response and error-handling scenarios.
  * Added global test helpers and a mock error creator to improve test setup reliability.
  * Introduced shared test-data builders and edge-case suites for store behavior.
  * Tightened test coverage thresholds in the test runner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->