### PR TITLE
chore: audit .env.example for completeness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
+# Base URL for the Manna Cloud REST API
 NUXT_PUBLIC_API_BASE_URL=https://your-api.com
-NUXT_PUBLIC_APP_NAME=BSF Tutorials
-NUXT_PUBLIC_DOMAIN_ALIAS=bsfmarket
+
+# Domain alias used for branding (default: bsfapp)
+NUXT_PUBLIC_DOMAIN_ALIAS=bsfapp
+
+# Set to 'false' to disable USD conversion; any other value keeps it on
+ENABLE_USD_CONVERSION=true
+
+# Optional API key for ExchangeRate-API; leave blank for keyless v4 fallback
+EXCHANGE_RATE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ workflows on web and mobile using Capacitor.
 
 1. Clone the repository.
 2. Install dependencies with `npm install`.
-3. Copy `.env.example` to `.env` and set `NUXT_PUBLIC_API_BASE_URL`.
+3. Copy `.env.example` to `.env` and fill in values as needed.
+   `.env.example` is the source of truth for all runtime env vars.
 4. Run the development server with `npm run dev` (http://localhost:3000).
 
 ## Core Experience
@@ -80,6 +81,8 @@ workflows on web and mobile using Capacitor.
 - `npm run build` – Production build validation.
 - `npm run test:e2e` – Playwright specs (requires running `npm run dev`
   in a separate terminal first).
+- Playwright-only env vars (`CI`, `PW_ALL=1` for full browser matrix)
+  are configured in `playwright.config.ts`, not `.env.example`.
 
 ## Architecture Notes
 


### PR DESCRIPTION
## Summary

- Add missing `ENABLE_USD_CONVERSION` and `EXCHANGE_RATE_API_KEY`
  entries to `.env.example` with descriptive comments
- Remove stale `NUXT_PUBLIC_APP_NAME` (unused in code)
- Fix `NUXT_PUBLIC_DOMAIN_ALIAS` default value (`bsfapp`, not
  `bsfmarket`)
- Update README installation step to reference `.env.example`
  generically as the source of truth for all env vars
- Add Playwright-only env vars note to README Testing section

Closes #31

## Test plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] `grep -nE "process\.env\." nuxt.config.ts` — all 4 hits
  map to `.env.example` entries
- [x] `cat .env.example` reads as a clean, commented list
- [ ] Manual: copy `.env.example` to `.env`, run `npm run dev`

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified environment variable configuration requirements in setup instructions
  * Updated default domain branding identifier

* **New Features**
  * Added configurable USD conversion capability with optional exchange rate API integration support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->