### PR TITLE
fix: validate localStorage reads uniformly in auth store

### DIFF
--- a/app/composables/useStorage.ts
+++ b/app/composables/useStorage.ts
@@ -10,7 +10,13 @@ export const useStorage = () => {
   const get = <T extends JsonSerializable>(key: string): T | null => {
     if (import.meta.client) {
       const item = localStorage.getItem(key)
-      return item ? (JSON.parse(item) as T) : null
+      if (item === null) return null
+      try {
+        return JSON.parse(item) as T
+      } catch {
+        localStorage.removeItem(key)
+        return null
+      }
     }
     return null
   }

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -74,6 +74,31 @@ export const useAuthStore = defineStore('auth', () => {
 
   const initializeAuth = () => {
     const storage = useStorage()
+
+    // Detect corrupt outer JSON before hydration
+    if (import.meta.client) {
+      const authKeys = [
+        'auth_token', 'auth_user',
+        'auth_active_company',
+        'auth_other_companies',
+        'auth_last_profile_fetch'
+      ]
+      for (const key of authKeys) {
+        const raw = localStorage.getItem(key)
+        if (raw === null) continue
+        try {
+          JSON.parse(raw)
+        } catch {
+          handleSilentError(
+            new Error('auth storage corrupted'),
+            'authStore.hydrate'
+          )
+          logout()
+          return
+        }
+      }
+    }
+
     const savedToken = storage.get<string>('auth_token')
     const savedUser = storage.get<string>('auth_user')
     const savedActiveCompany = storage.get<string>('auth_active_company')
@@ -87,7 +112,11 @@ export const useAuthStore = defineStore('auth', () => {
     if (savedUser) {
       try {
         const parsed = JSON.parse(savedUser)
-        if (typeof parsed !== 'object' || parsed === null) {
+        if (
+          typeof parsed !== 'object'
+          || parsed === null
+          || Array.isArray(parsed)
+        ) {
           throw new Error('not an object')
         }
         user.value = parsed
@@ -101,7 +130,11 @@ export const useAuthStore = defineStore('auth', () => {
     if (savedActiveCompany) {
       try {
         const parsed = JSON.parse(savedActiveCompany)
-        if (typeof parsed !== 'object' || parsed === null) {
+        if (
+          typeof parsed !== 'object'
+          || parsed === null
+          || Array.isArray(parsed)
+        ) {
           throw new Error('not an object')
         }
         activeCompany.value = parsed

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -86,38 +86,54 @@ export const useAuthStore = defineStore('auth', () => {
 
     if (savedUser) {
       try {
-        user.value = JSON.parse(savedUser)
-      } catch (error) {
-        handleSilentError(error, 'authStore.hydrate')
-        storage.remove('auth_user')
+        const parsed = JSON.parse(savedUser)
+        if (typeof parsed !== 'object' || parsed === null) {
+          throw new Error('not an object')
+        }
+        user.value = parsed
+      } catch {
+        handleSilentError(new Error('auth storage corrupted'), 'authStore.hydrate')
+        logout()
+        return
       }
     }
 
     if (savedActiveCompany) {
       try {
-        activeCompany.value = JSON.parse(savedActiveCompany)
-      } catch (error) {
-        handleSilentError(error, 'authStore.hydrate')
-        storage.remove('auth_active_company')
+        const parsed = JSON.parse(savedActiveCompany)
+        if (typeof parsed !== 'object' || parsed === null) {
+          throw new Error('not an object')
+        }
+        activeCompany.value = parsed
+      } catch {
+        handleSilentError(new Error('auth storage corrupted'), 'authStore.hydrate')
+        logout()
+        return
       }
     }
 
     if (savedOtherCompanies) {
       try {
-        otherCompanies.value = JSON.parse(savedOtherCompanies)
-      } catch (error) {
-        handleSilentError(error, 'authStore.hydrate')
-        storage.remove('auth_other_companies')
+        const parsed = JSON.parse(savedOtherCompanies)
+        if (!Array.isArray(parsed)) {
+          throw new Error('not an array')
+        }
+        otherCompanies.value = parsed
+      } catch {
+        handleSilentError(new Error('auth storage corrupted'), 'authStore.hydrate')
+        logout()
+        return
       }
     }
 
     if (savedLastProfileFetch) {
-      try {
-        lastProfileFetch.value = parseInt(savedLastProfileFetch) || 0
-      } catch (error) {
-        handleSilentError(error, 'authStore.hydrate')
-        storage.remove('auth_last_profile_fetch')
+      const parsed = parseInt(savedLastProfileFetch, 10)
+      if (Number.isNaN(parsed) || parsed <= 0) {
+        handleSilentError(new Error('auth storage corrupted'), 'authStore.hydrate')
+        logout()
+        return
       }
+      lastProfileFetch.value = parsed
     }
   }
 

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -78,7 +78,8 @@ export const useAuthStore = defineStore('auth', () => {
     // Detect corrupt outer JSON before hydration
     if (import.meta.client) {
       const authKeys = [
-        'auth_token', 'auth_user',
+        'auth_token',
+        'auth_user',
         'auth_active_company',
         'auth_other_companies',
         'auth_last_profile_fetch'
@@ -89,10 +90,7 @@ export const useAuthStore = defineStore('auth', () => {
         try {
           JSON.parse(raw)
         } catch {
-          handleSilentError(
-            new Error('auth storage corrupted'),
-            'authStore.hydrate'
-          )
+          handleSilentError(new Error('auth storage corrupted'), 'authStore.hydrate')
           logout()
           return
         }
@@ -112,11 +110,7 @@ export const useAuthStore = defineStore('auth', () => {
     if (savedUser) {
       try {
         const parsed = JSON.parse(savedUser)
-        if (
-          typeof parsed !== 'object'
-          || parsed === null
-          || Array.isArray(parsed)
-        ) {
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
           throw new Error('not an object')
         }
         user.value = parsed
@@ -130,11 +124,7 @@ export const useAuthStore = defineStore('auth', () => {
     if (savedActiveCompany) {
       try {
         const parsed = JSON.parse(savedActiveCompany)
-        if (
-          typeof parsed !== 'object'
-          || parsed === null
-          || Array.isArray(parsed)
-        ) {
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
           throw new Error('not an object')
         }
         activeCompany.value = parsed

--- a/tests/unit/composables/useStorage.test.ts
+++ b/tests/unit/composables/useStorage.test.ts
@@ -84,11 +84,9 @@ describe('useStorage composable', () => {
     })
   })
 
-  describe('corruption handling (contract — should fail red)', () => {
-    // These tests define the desired behavior: get() should
-    // return null and remove the key when localStorage holds
-    // unparseable data. The current implementation has no
-    // try/catch around JSON.parse so these will throw.
+  describe('corruption handling', () => {
+    // Verifies get() returns null and removes the key
+    // when localStorage holds unparseable JSON data.
 
     const corruptValues = ['{not json', 'undefined', '[1,', '{"a":}']
 

--- a/tests/unit/composables/useStorage.test.ts
+++ b/tests/unit/composables/useStorage.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useStorage } from '~/composables/useStorage'
+
+describe('useStorage composable', () => {
+  // NOTE: SSR branch (import.meta.client === false) is unreachable
+  // in jsdom because vitest.config.mjs replaces import.meta.client
+  // with (!import.meta.env?.SSR) which is always true.
+
+  let storage: ReturnType<typeof useStorage>
+
+  beforeEach(() => {
+    storage = useStorage()
+  })
+
+  describe('round-trip primitives', () => {
+    it('stores and retrieves a string', () => {
+      storage.set('k-str', 'hello')
+      expect(storage.get<string>('k-str')).toBe('hello')
+    })
+
+    it('stores and retrieves a number', () => {
+      storage.set('k-num', 42)
+      expect(storage.get<number>('k-num')).toBe(42)
+    })
+
+    it('stores and retrieves a boolean', () => {
+      storage.set('k-bool', true)
+      expect(storage.get<boolean>('k-bool')).toBe(true)
+    })
+  })
+
+  describe('round-trip complex types', () => {
+    it('stores and retrieves an object', () => {
+      const obj = { name: 'Alice', age: 30 }
+      storage.set('k-obj', obj)
+      expect(storage.get('k-obj')).toEqual(obj)
+    })
+
+    it('stores and retrieves an array', () => {
+      const arr = [1, 'two', { three: 3 }]
+      storage.set('k-arr', arr)
+      expect(storage.get('k-arr')).toEqual(arr)
+    })
+  })
+
+  describe('missing keys', () => {
+    it('returns null for a key that was never set', () => {
+      expect(storage.get('never-set')).toBeNull()
+    })
+
+    it('does not call removeItem for a missing key', () => {
+      storage.get('never-set')
+      expect(localStorage.removeItem).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('set writes JSON.stringify value', () => {
+    it('raw localStorage value is JSON-stringified', () => {
+      storage.set('k-raw', { a: 1 })
+      const raw = localStorage.getItem('k-raw')
+      expect(raw).toBe(JSON.stringify({ a: 1 }))
+    })
+
+    it('string value is double-quoted in storage', () => {
+      storage.set('k-raw-str', 'hello')
+      const raw = localStorage.getItem('k-raw-str')
+      expect(raw).toBe('"hello"')
+    })
+  })
+
+  describe('remove and clear', () => {
+    it('remove deletes a single key', () => {
+      storage.set('k-del', 'value')
+      storage.remove('k-del')
+      expect(storage.get('k-del')).toBeNull()
+    })
+
+    it('clear removes all keys', () => {
+      storage.set('k1', 'a')
+      storage.set('k2', 'b')
+      storage.clear()
+      expect(storage.get('k1')).toBeNull()
+      expect(storage.get('k2')).toBeNull()
+    })
+  })
+
+  describe('corruption handling (contract — should fail red)', () => {
+    // These tests define the desired behavior: get() should
+    // return null and remove the key when localStorage holds
+    // unparseable data. The current implementation has no
+    // try/catch around JSON.parse so these will throw.
+
+    const corruptValues = ['{not json', 'undefined', '[1,', '{"a":}']
+
+    it.each(corruptValues)('returns null for corrupt value: %s', corrupt => {
+      localStorage.setItem('bad', corrupt)
+      expect(storage.get('bad')).toBeNull()
+    })
+
+    it.each(corruptValues)('removes corrupt key from localStorage: %s', corrupt => {
+      localStorage.setItem('bad', corrupt)
+      storage.get('bad')
+      expect(localStorage.getItem('bad')).toBeNull()
+    })
+
+    it('does not throw for corrupt data', () => {
+      localStorage.setItem('bad', '{not json')
+      expect(() => storage.get('bad')).not.toThrow()
+    })
+  })
+})

--- a/tests/unit/stores/auth.test.ts
+++ b/tests/unit/stores/auth.test.ts
@@ -656,3 +656,163 @@ describe('Auth Store - Auto-select Active Company Feature', () => {
     })
   })
 })
+
+describe('initializeAuth corruption handling', () => {
+  // This block tests that initializeAuth performs a full
+  // logout when any stored value is corrupt, rather than
+  // silently skipping individual fields.
+
+  const AUTH_KEYS = [
+    'auth_token',
+    'auth_user',
+    'auth_active_company',
+    'auth_other_companies',
+    'auth_last_profile_fetch'
+  ] as const
+
+  let store: ReturnType<typeof useAuthStore>
+  let mockRemove: ReturnType<typeof vi.fn>
+
+  // Valid seed values — these simulate what storage.get()
+  // returns AFTER a safe JSON.parse. The mock get() returns
+  // these directly (no parse).
+  const validUser = JSON.stringify({
+    _id: 'u1',
+    email: 'a@b.c',
+    balance: 0
+  })
+  const validActiveCompany = JSON.stringify({
+    _id: 'c1',
+    name: 'Co'
+  })
+  const validOtherCompanies = JSON.stringify([{ _id: 'c2', name: 'Other' }])
+
+  function seedValid() {
+    mockStorage['auth_token'] = 'tok-1'
+    mockStorage['auth_user'] = validUser
+    mockStorage['auth_active_company'] = validActiveCompany
+    mockStorage['auth_other_companies'] = validOtherCompanies
+    mockStorage['auth_last_profile_fetch'] = '1700000000000'
+  }
+
+  function clearMockStorage() {
+    const keys = Object.keys(mockStorage)
+    keys.forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(mockStorage, key)) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete mockStorage[key]
+      }
+    })
+  }
+
+  function allKeysAbsent(): boolean {
+    return AUTH_KEYS.every(k => mockStorage[k] === undefined)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearMockStorage()
+    setActivePinia(createPinia())
+    store = useAuthStore()
+    mockRemove = vi.fn((key: string) => {
+      const keys = Object.keys(mockStorage)
+      keys.forEach(k => {
+        if (k === key && Object.prototype.hasOwnProperty.call(mockStorage, k)) {
+          // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+          delete mockStorage[k]
+        }
+      })
+    })
+    // Override the global mock's remove to track calls
+    const prevGet = global.useStorage().get
+    const prevSet = global.useStorage().set
+    const prevClear = global.useStorage().clear
+    global.useStorage = () => ({
+      get: prevGet,
+      set: prevSet,
+      remove: mockRemove,
+      clear: prevClear
+    })
+  })
+
+  it('hydrates all fields when all keys are valid', () => {
+    seedValid()
+    store.initializeAuth()
+    expect(store.token).toBe('tok-1')
+    expect(store.user).toBeTruthy()
+    expect(store.activeCompany).toBeTruthy()
+    expect(store.otherCompanies.length).toBeGreaterThan(0)
+    expect(store.lastProfileFetch).toBeGreaterThan(0)
+    // All keys still present
+    AUTH_KEYS.forEach(k => {
+      expect(mockStorage[k]).toBeDefined()
+    })
+  })
+
+  it('stays at initial values when no keys exist', () => {
+    store.initializeAuth()
+    expect(store.token).toBeNull()
+    expect(store.user).toBeNull()
+    expect(store.activeCompany).toBeNull()
+    expect(store.otherCompanies).toEqual([])
+    expect(store.lastProfileFetch).toBe(0)
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
+
+  it('hydrates token only when others are missing', () => {
+    mockStorage['auth_token'] = 'tok-1'
+    store.initializeAuth()
+    expect(store.token).toBe('tok-1')
+    expect(store.user).toBeNull()
+    // No reset triggered — remove not called
+    expect(mockRemove).not.toHaveBeenCalled()
+  })
+
+  // --- Corruption tests (expected to FAIL red) ---
+  // The current initializeAuth does per-field try/catch and
+  // only removes the single corrupt key. The desired behavior
+  // is a full logout that clears ALL 5 keys.
+
+  it('corrupt auth_user triggers full reset ' + '(all keys removed)', () => {
+    seedValid()
+    mockStorage['auth_user'] = '{not-json'
+    store.initializeAuth()
+    expect(store.token).toBeNull()
+    expect(store.user).toBeNull()
+    expect(store.activeCompany).toBeNull()
+    expect(allKeysAbsent()).toBe(true)
+  })
+
+  it('corrupt auth_active_company triggers full reset', () => {
+    seedValid()
+    mockStorage['auth_active_company'] = '{bad'
+    store.initializeAuth()
+    expect(store.token).toBeNull()
+    expect(allKeysAbsent()).toBe(true)
+  })
+
+  it('corrupt auth_other_companies triggers full reset', () => {
+    seedValid()
+    mockStorage['auth_other_companies'] = '[broken'
+    store.initializeAuth()
+    expect(store.token).toBeNull()
+    expect(allKeysAbsent()).toBe(true)
+  })
+
+  it('corrupt auth_last_profile_fetch triggers full reset', () => {
+    seedValid()
+    mockStorage['auth_last_profile_fetch'] = 'NaN-bad'
+    store.initializeAuth()
+    expect(store.token).toBeNull()
+    expect(allKeysAbsent()).toBe(true)
+  })
+
+  it('corrupt inner user JSON triggers full reset', () => {
+    seedValid()
+    // Valid outer string, invalid inner JSON
+    mockStorage['auth_user'] = JSON.stringify('{not-json-inner')
+    store.initializeAuth()
+    expect(store.token).toBeNull()
+    expect(allKeysAbsent()).toBe(true)
+  })
+})

--- a/tests/unit/stores/auth.test.ts
+++ b/tests/unit/stores/auth.test.ts
@@ -689,10 +689,15 @@ describe('initializeAuth corruption handling', () => {
 
   function seedValid() {
     mockStorage['auth_token'] = 'tok-1'
+    localStorage.setItem('auth_token', JSON.stringify('tok-1'))
     mockStorage['auth_user'] = validUser
+    localStorage.setItem('auth_user', validUser)
     mockStorage['auth_active_company'] = validActiveCompany
+    localStorage.setItem('auth_active_company', validActiveCompany)
     mockStorage['auth_other_companies'] = validOtherCompanies
+    localStorage.setItem('auth_other_companies', validOtherCompanies)
     mockStorage['auth_last_profile_fetch'] = '1700000000000'
+    localStorage.setItem('auth_last_profile_fetch', JSON.stringify('1700000000000'))
   }
 
   function clearMockStorage() {
@@ -761,6 +766,7 @@ describe('initializeAuth corruption handling', () => {
 
   it('hydrates token only when others are missing', () => {
     mockStorage['auth_token'] = 'tok-1'
+    localStorage.setItem('auth_token', JSON.stringify('tok-1'))
     store.initializeAuth()
     expect(store.token).toBe('tok-1')
     expect(store.user).toBeNull()
@@ -768,14 +774,13 @@ describe('initializeAuth corruption handling', () => {
     expect(mockRemove).not.toHaveBeenCalled()
   })
 
-  // --- Corruption tests (expected to FAIL red) ---
-  // The current initializeAuth does per-field try/catch and
-  // only removes the single corrupt key. The desired behavior
-  // is a full logout that clears ALL 5 keys.
+  // Corruption in any auth key triggers full logout
+  // and clears all auth-related storage keys.
 
   it('corrupt auth_user triggers full reset ' + '(all keys removed)', () => {
     seedValid()
     mockStorage['auth_user'] = '{not-json'
+    localStorage.setItem('auth_user', '{not-json')
     store.initializeAuth()
     expect(store.token).toBeNull()
     expect(store.user).toBeNull()
@@ -786,6 +791,7 @@ describe('initializeAuth corruption handling', () => {
   it('corrupt auth_active_company triggers full reset', () => {
     seedValid()
     mockStorage['auth_active_company'] = '{bad'
+    localStorage.setItem('auth_active_company', '{bad')
     store.initializeAuth()
     expect(store.token).toBeNull()
     expect(allKeysAbsent()).toBe(true)
@@ -794,6 +800,7 @@ describe('initializeAuth corruption handling', () => {
   it('corrupt auth_other_companies triggers full reset', () => {
     seedValid()
     mockStorage['auth_other_companies'] = '[broken'
+    localStorage.setItem('auth_other_companies', '[broken')
     store.initializeAuth()
     expect(store.token).toBeNull()
     expect(allKeysAbsent()).toBe(true)
@@ -802,6 +809,7 @@ describe('initializeAuth corruption handling', () => {
   it('corrupt auth_last_profile_fetch triggers full reset', () => {
     seedValid()
     mockStorage['auth_last_profile_fetch'] = 'NaN-bad'
+    localStorage.setItem('auth_last_profile_fetch', 'NaN-bad')
     store.initializeAuth()
     expect(store.token).toBeNull()
     expect(allKeysAbsent()).toBe(true)
@@ -810,7 +818,9 @@ describe('initializeAuth corruption handling', () => {
   it('corrupt inner user JSON triggers full reset', () => {
     seedValid()
     // Valid outer string, invalid inner JSON
-    mockStorage['auth_user'] = JSON.stringify('{not-json-inner')
+    const corruptValue = JSON.stringify('{not-json-inner')
+    mockStorage['auth_user'] = corruptValue
+    localStorage.setItem('auth_user', corruptValue)
     store.initializeAuth()
     expect(store.token).toBeNull()
     expect(allKeysAbsent()).toBe(true)


### PR DESCRIPTION
## Summary

- **`useStorage.get()`** now wraps `JSON.parse` in try/catch — corrupt keys are auto-removed and `null` is returned instead of throwing
- **`initializeAuth`** detects corruption (invalid JSON, wrong types, invalid timestamps) and calls `logout()` for a full reset instead of per-field cleanup that left mixed auth state
- Added `useStorage.test.ts` (20 tests) and extended `auth.test.ts` with 8 corruption handling tests

Closes #32

## Test plan

- [x] `useStorage.get()` returns null and removes key for corrupt JSON (`'{not json'`, `'undefined'`, `'[1,'`, `'{"a":}`)
- [x] `useStorage.get()` never throws on corrupt data
- [x] Valid round-trip for primitives, objects, arrays
- [x] Missing keys return null without side effects
- [x] All valid auth keys → store hydrates correctly
- [x] All missing auth keys → store stays at initial, no remove called
- [x] Token-only partial state → token hydrates, no reset
- [x] Corrupt any single auth key → full logout (all 5 keys cleared)
- [x] Corrupt inner user JSON → full logout
- [x] Existing auth tests (19) still pass
- [x] `useApi.test.ts` and `useUserRole.test.ts` still pass
- [x] Lint, format, typecheck all green

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear corrupted local storage entries instead of throwing; missing keys still return null.
  * Auth initialization validates stored auth values and aborts with a full logout/reset when corruption is detected.

* **Tests**
  * Added tests for storage round-trips, corruption handling, and auth initialization edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->