### PR TITLE
fix: ErrorCard retry wiring mismatch in tutorials.vue

### DIFF
--- a/app/pages/tutorials.vue
+++ b/app/pages/tutorials.vue
@@ -29,8 +29,8 @@
         <ion-col size="12" size-md="8" size-lg="6">
           <ErrorCard
             :message="t('tutorials.error.title')"
-            :retry-action="retryLoad"
             :retry-label="t('tutorials.error.retry')"
+            @retry="retryLoad"
           />
         </ion-col>
       </ion-row>

--- a/tests/unit/pages/tutorials.test.ts
+++ b/tests/unit/pages/tutorials.test.ts
@@ -80,9 +80,9 @@ async function mountPage(
           template:
             '<div class="error-stub">' +
             '<button class="retry" ' +
-            '@click="$attrs[\'retry-action\']()">' +
+            '@click="$emit(\'retry\')">' +
             'retry</button></div>',
-          inheritAttrs: false
+          emits: ['retry']
         },
         VideoCard: {
           template: '<div class="video-card-stub">' + '{{ video.title }}</div>',


### PR DESCRIPTION
## Summary
- Swap `:retry-action="retryLoad"` (non-existent prop) to `@retry="retryLoad"` (correct event binding) on ErrorCard in `tutorials.vue`
- Update test stub to emit `retry` event instead of reading `$attrs['retry-action']`, matching the real ErrorCard contract
- Fix Vue attribute ordering (props before events)

## Verification
- `npx eslint` — clean
- `npx prettier --check` — clean
- `npm run typecheck` — clean
- `npx vitest run tests/unit/pages/tutorials.test.ts` — 27/27 pass
- `npm run build` — success

## Test plan
- [x] Existing retry test passes with corrected stub
- [x] All 27 tutorial page tests pass
- [x] Lint, format, typecheck, build all green
- [ ] Manual: force `loadPublic()` error in devtools, click retry, confirm network call fires

Closes #38

Generated by flow_ai workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated error handling component to use event-based communication instead of property binding for improved modularity.
  * Updated corresponding tests to reflect the new interaction pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->