### PR TITLE
fix: give the read-only analysis agents a shell

### DIFF
--- a/.claude/agents/analyze-issue-architect.md
+++ b/.claude/agents/analyze-issue-architect.md
@@ -3,7 +3,7 @@ name: issue-analyzer-architect
 description: Analyzes issues for architectural
   improvements and modularity
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch,
-  BashOutput, KillShell,
+  Bash, BashOutput, KillShell,
   mcp__context7__resolve-library-id,
   mcp__context7__get-library-docs
 model: opus

--- a/.claude/agents/analyze-issue-careful.md
+++ b/.claude/agents/analyze-issue-careful.md
@@ -3,7 +3,7 @@ name: issue-analyzer-careful
 description: Analyzes issues for minimal side effects
   and maximum safety
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch,
-  BashOutput, KillShell,
+  Bash, BashOutput, KillShell,
   mcp__context7__resolve-library-id,
   mcp__context7__get-library-docs
 model: opus

--- a/.claude/agents/analyze-issue-lazy.md
+++ b/.claude/agents/analyze-issue-lazy.md
@@ -3,7 +3,7 @@ name: issue-analyzer-lazy
 description: Analyzes issues for minimal, quick-fix
   solutions
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch,
-  BashOutput, KillShell,
+  Bash, BashOutput, KillShell,
   mcp__context7__resolve-library-id,
   mcp__context7__get-library-docs
 model: opus

--- a/.claude/agents/evaluate-code-quality.md
+++ b/.claude/agents/evaluate-code-quality.md
@@ -3,7 +3,7 @@ name: code-quality-evaluator
 description: Expert code quality evaluator for thorough
   code review
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch,
-  BashOutput, KillShell,
+  Bash, BashOutput, KillShell,
   mcp__context7__resolve-library-id,
   mcp__context7__get-library-docs
 model: opus

--- a/.claude/agents/evaluate-frontend-quality.md
+++ b/.claude/agents/evaluate-frontend-quality.md
@@ -3,7 +3,7 @@ name: frontend-quality-evaluator
 description: UI/UX and frontend code quality evaluator
   focused on modularity, accessibility, and maintainability
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch,
-  BashOutput, KillShell,
+  Bash, BashOutput, KillShell,
   mcp__context7__resolve-library-id,
   mcp__context7__get-library-docs
 model: opus

--- a/.claude/agents/implement-test-driven.md
+++ b/.claude/agents/implement-test-driven.md
@@ -3,7 +3,7 @@ name: test-driven-engineer
 description: Evaluates and enhances testing strategies
   for issues
 tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch,
-  BashOutput, KillShell,
+  Bash, BashOutput, KillShell,
   mcp__context7__resolve-library-id,
   mcp__context7__get-library-docs
 model: opus


### PR DESCRIPTION
`BashOutput` and `KillShell` were listed without `Bash`, which is incoherent: both exist only to read from or kill a shell that `Bash` started. The analyse-issue finalize evaluators spent runs announcing they had no shell and trying to reach GitHub over WebFetch instead.

Config-only change to `.claude/agents/*.md` frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kp96SYpzjyDhrVoqnkktVo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded available command-line capabilities for automated analysis, evaluation, and implementation workflows.
  * Enabled supported workflows to run shell commands directly when needed.

* **Chores**
  * Standardized command execution access across multiple development and review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->